### PR TITLE
Add 6 novel research hypotheses with prior art analysis

### DIFF
--- a/research/README.md
+++ b/research/README.md
@@ -6,25 +6,29 @@ Running large LLMs (70B+) on a 24GB M4 MacBook Pro. The model weights alone exce
 
 ## Three Bottlenecks
 
-| Bottleneck | Constraint | Hard Number |
-|-----------|-----------|-------------|
-| **Memory capacity** | 24GB unified, ~19-21GB usable | Q4 70B = 40GB weights |
-| **Memory bandwidth** | ~120 GB/s on M4 | Max ~3 tok/s for 40GB model |
-| **Compute** | ~4 TFLOPS FP32 | Rarely the bottleneck at batch=1 |
+
+| Bottleneck           | Constraint                    | Hard Number                      |
+| -------------------- | ----------------------------- | -------------------------------- |
+| **Memory capacity**  | 24GB unified, ~19-21GB usable | Q4 70B = 40GB weights            |
+| **Memory bandwidth** | ~120 GB/s on M4               | Max ~3 tok/s for 40GB model      |
+| **Compute**          | ~4 TFLOPS FP32                | Rarely the bottleneck at batch=1 |
+
 
 ## Hypotheses
 
 Each hypothesis draws an analogy from another field of computer science where similar constraints were overcome.
 
-| # | Hypothesis | Analogy | Prior Art | Actionability |
-|---|-----------|---------|-----------|---------------|
-| H0 | [Expert offloading / SSD streaming](./h0-expert-offloading.md) | Virtual memory / demand paging | Flash MOE, HOBBIT (9.93x), FlashMoE (51% better cache) | **Tested — Promising. 30B on 16GB confirmed.** |
-| H1 | [Adaptive precision per token](./h1-adaptive-precision.md) | Adaptive bitrate streaming | FlexQuant (1.3x), EAD (41-67% compute reduction), ML-SpecQD (2.72x), JANG (Apple Silicon) | Medium — needs custom implementation |
-| H2 | [Expert routing prediction + prefetch](./h2-routing-prediction.md) | CPU branch prediction | 12+ papers, 93-97% prediction accuracy, up to 5x speedup (ProMoE) | High — well-validated, clear implementation path |
-| H3 | [Prompt-aware weight pre-loading](./h3-prompt-aware-loading.md) | Database query planning | SiDA-MoE (3.93x), eMoE (80% mem reduction), expert specialization confirmed | Medium — building blocks exist, end-to-end gap |
-| H4 | [Low-rank base + sparse SSD corrections](./h4-lowrank-corrections.md) | Compressed sensing | SVD-LLM (1.6x), HASSLE-free, CALDERA (<2.5bpw SOTA), Hypura (Apple Silicon) | Medium — decomposition solved, system gap |
-| H5 | [Layer LOD — variable precision by depth](./h5-layer-lod.md) | Game engine LOD | U-shape confirmed, mlx-optiq (2.3x accuracy), llama.cpp regex quant, CoopQ | **Highest — immediately actionable with existing tools** |
-| H6 | [Activation sparsity prediction](./h6-activation-sparsity.md) | Frustum culling | PowerInfer (27.8x), TEAL (1.5-1.8x, training-free), TurboSparse (90% sparsity) | **High — TEAL requires zero training, CMoE converts in 5 min** |
+
+| #   | Hypothesis                                                            | Analogy                        | Prior Art                                                                                 | Actionability                                                  |
+| --- | --------------------------------------------------------------------- | ------------------------------ | ----------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| H0  | [Expert offloading / SSD streaming](./h0-expert-offloading.md)        | Virtual memory / demand paging | Flash MOE, HOBBIT (9.93x), FlashMoE (51% better cache)                                    | **Tested — Promising. 30B on 16GB confirmed.**                 |
+| H1  | [Adaptive precision per token](./h1-adaptive-precision.md)            | Adaptive bitrate streaming     | FlexQuant (1.3x), EAD (41-67% compute reduction), ML-SpecQD (2.72x), JANG (Apple Silicon) | Medium — needs custom implementation                           |
+| H2  | [Expert routing prediction + prefetch](./h2-routing-prediction.md)    | CPU branch prediction          | 12+ papers, 93-97% prediction accuracy, up to 5x speedup (ProMoE)                         | High — well-validated, clear implementation path               |
+| H3  | [Prompt-aware weight pre-loading](./h3-prompt-aware-loading.md)       | Database query planning        | SiDA-MoE (3.93x), eMoE (80% mem reduction), expert specialization confirmed               | Medium — building blocks exist, end-to-end gap                 |
+| H4  | [Low-rank base + sparse SSD corrections](./h4-lowrank-corrections.md) | Compressed sensing             | SVD-LLM (1.6x), HASSLE-free, CALDERA (<2.5bpw SOTA), Hypura (Apple Silicon)               | Medium — decomposition solved, system gap                      |
+| H5  | [Layer LOD — variable precision by depth](./h5-layer-lod.md)          | Game engine LOD                | U-shape confirmed, mlx-optiq (2.3x accuracy), llama.cpp regex quant, CoopQ                | **Highest — immediately actionable with existing tools**       |
+| H6  | [Activation sparsity prediction](./h6-activation-sparsity.md)         | Frustum culling                | PowerInfer (27.8x), TEAL (1.5-1.8x, training-free), TurboSparse (90% sparsity)            | **High — TEAL requires zero training, CMoE converts in 5 min** |
+
 
 ## How to Use This
 
@@ -41,3 +45,4 @@ Each hypothesis draws an analogy from another field of computer science where si
 - **Promising** — Positive results, worth pursuing further
 - **Mixed** — Some benefit, significant trade-offs
 - **Dead End** — Tested, doesn't work for our constraints
+

--- a/research/h1-adaptive-precision.md
+++ b/research/h1-adaptive-precision.md
@@ -1,0 +1,115 @@
+# H1: Adaptive Precision Per Token
+
+**Status**: Untested
+**Analogy**: Adaptive bitrate streaming (Netflix, YouTube)
+**Bottleneck addressed**: Memory bandwidth
+
+## The Insight
+
+In adaptive bitrate video streaming, the server sends low-resolution frames when bandwidth is tight and high-resolution when it's available. The viewer rarely notices because most frames are predictable.
+
+LLM token generation has the same property: **most tokens are "easy"** (high confidence, low entropy). The model could predict "the" or "of" with Q2 weights just as well as Q8. Only ambiguous tokens — where the top-k probabilities are close — actually benefit from higher precision.
+
+## Hypothesis
+
+> If we use Q2 weights for high-confidence tokens and dynamically load Q4/Q8 weights only for low-confidence tokens, we can achieve near-Q4 quality at near-Q2 bandwidth cost.
+
+## Mechanism
+
+```
+For each token:
+  1. Run forward pass with Q2 weights (fast, in RAM)
+  2. Check output entropy / top-k confidence gap
+  3. If confident (entropy < threshold): accept token, move on
+  4. If uncertain (entropy ≥ threshold):
+     a. Load Q4/Q8 weights for critical layers from SSD
+     b. Re-run those layers at higher precision
+     c. Accept the refined token
+```
+
+## Expected Impact
+
+- **Bandwidth savings**: If 70-80% of tokens are "easy", we only need high-precision weights for 20-30% of tokens
+- **Effective throughput**: 3-5x over running everything at Q4
+- **Quality**: Near-Q4 perplexity since hard tokens still get full precision
+
+## Prior Art (Research Findings)
+
+### Token Entropy Distribution — The Empirical Foundation
+
+**~80% of tokens are "easy"** — this is now well-established:
+- [Beyond the 80/20 Rule (Wang et al., 2025)](https://arxiv.org/abs/2506.01939): >50% of CoT tokens have near-zero entropy (H_t < 0.01). Only the top ~20% are genuine "forking tokens" (H_t > 0.672). Training on only the low-entropy 80% produced "marked performance decline" — confirming they're predictable.
+- [DiffAdapt (Liu et al., 2025)](https://arxiv.org/abs/2510.19669): Up to 62% token reduction via difficulty-adaptive reasoning. Uses a lightweight hidden-state probe to classify easy/normal/hard tokens.
+
+### Dynamic Per-Token Precision Switching
+
+- **[FlexQuant (2025)](https://arxiv.org/abs/2506.12024)**: The closest paper to our exact idea. Monitors entropy + KL divergence per token step, switches between INT8 and INT4 layers. **1.3x speedup** over static INT8, ROUGE-L within ~2-3% of full precision. Limitation: only 4-bit/8-bit, modest gains, switching overhead limits benefit.
+- **[FlexQuant — edge variant (2025)](https://arxiv.org/abs/2501.07139)**: Addresses memory fluctuation on edge devices. Generates an ensemble of quantized model variants, swaps between them based on runtime memory pressure. 15x granularity improvement. Memory-pressure-driven, not token-difficulty-driven, but similar mechanism.
+- **[DTQAtten (DATE 2022)](https://ieeexplore.ieee.org/document/9774692/)**: Two-level top-K engine for attention: full precision for top tokens, 4-bit for middle tier, 0-bit (discarded) for bottom. 40.5% average 4-bit ratio. Encoder-only, but insight transfers.
+
+### Entropy-Based Model/Precision Switching
+
+- **[Entropy Adaptive Decoding (EAD, 2025)](https://arxiv.org/abs/2502.06833)**: Routes between small and large model based on rolling entropy. **96.7% of 11B performance while using the large model for only 43% of tokens (41.5% compute reduction)**. On Qwen: large model used for only 25% of tokens (67% compute reduction). Does NOT verify — accepts controlled quality divergence.
+- **[ML-SpecQD (2025)](https://arxiv.org/abs/2503.13565)**: Uses MXFP4 quantized version of same model as draft in speculative decoding. **71.2% acceptance rate** (vs 41.7% for a separate small draft). **2.72x speedup** with three-level hierarchy. This IS adaptive precision expressed as speculative decoding.
+- **[Entropy-Aware Speculative Decoding (2024)](https://arxiv.org/abs/2512.23765)**: When both draft and target have high entropy, reject the draft. Actually surpasses target model quality in some cases by catching uncertainty cascades.
+
+### Early Exit / Adaptive Depth (Adjacent Approach)
+
+- **[CALM (Google, NeurIPS 2022)](https://arxiv.org/abs/2207.07061)**: Tokens exit at intermediate layers when confidence exceeds threshold. **Up to 3x speedup** on summarization. Challenge: KV cache consistency for tokens that exit early.
+- **[SpecEE (ISCA 2025)](https://arxiv.org/abs/2504.08850)**: Speculative early exiting with lightweight predictor. **2.25x speedup on Llama2-7B** (cloud), **2.43x (edge/llama.cpp)**. Has llama.cpp implementation — directly applicable to M4.
+- **[ADEPT (2026)](https://arxiv.org/abs/2601.03700)**: Extends early exit to both prefill and generation. Addresses KV cache problem for skipped layers.
+
+### Per-Component Static Mixed Precision (Apple Silicon)
+
+- **[JANG/jangq (2025)](https://github.com/jjang-ai/jangq)**: MLX-native, Apple Silicon optimized. Attention layers at 8-bit (1-5% of params), expert/MLP at 2-3 bit (95%+ of params). **Qwen3.5-397B at 2.1-bit avg: 86.5% MMLU**. MLX produces NaN below 4-bit on the same model without this technique. Proves the precision differentiation principle works on Apple Silicon.
+- **[MoQAE (ACL 2025)](https://arxiv.org/abs/2506.07533)**: Treats different quantization bit-widths as "experts", routes token chunks to different quant configs via a trained router.
+
+### Key Numbers
+
+| Metric | Value | Source |
+|--------|-------|--------|
+| Easy tokens in CoT | ~80% | arxiv 2506.01939 |
+| Large model needed (LLaMA) | 43% of tokens | EAD |
+| Large model needed (Qwen) | 25% of tokens | EAD |
+| CALM speedup | up to 3x | arxiv 2207.07061 |
+| SpecEE speedup (llama.cpp) | 2.43x | arxiv 2504.08850 |
+| FlexQuant speedup | 1.3x | arxiv 2506.12024 |
+| ML-SpecQD speedup (3-level) | 2.72x | arxiv 2503.13565 |
+| MXFP4 draft acceptance rate | 71.2% | arxiv 2503.13565 |
+
+### The Gap
+
+The exact mechanism — token-by-token dynamic weight dequantization at Q2 vs Q4 vs Q8 based on real-time entropy — has **not** been cleanly implemented end-to-end. FlexQuant is closest but limited to 4/8-bit with modest gains. ML-SpecQD achieves the effect via speculative decoding but is hardware-specific (MXFP4). JANG proves per-component precision works on Apple Silicon but is static.
+
+The missing piece: a system that computes token entropy during generation, gates between Q2/Q4 weights for the same model per-token, and maintains KV cache consistency. The 80/20 distribution data suggests 40-67% compute reduction is achievable.
+
+## Open Questions
+
+1. What's the right confidence threshold? Too low = quality loss. Too high = no savings.
+2. How fast can we load higher-precision weights from SSD for a subset of layers? If the overhead of switching precision exceeds the savings, this doesn't work.
+3. Do we need both Q2 and Q4 copies of all weights, or can we store a Q2 base + Q4 "correction" deltas?
+4. Which layers benefit most from higher precision on hard tokens? Probably attention > FFN (confirmed by JANG).
+5. ~~What fraction of tokens in typical workloads (chat, code, reasoning) are "easy"?~~ **Answered: ~80% are easy** (arxiv 2506.01939).
+6. Can ML-SpecQD's approach (quantized draft of same model) be adapted for Apple Silicon / Metal?
+7. Is SpecEE (early exit, has llama.cpp implementation) a more practical starting point than full precision switching?
+
+## Experiment Plan
+
+### Phase 1: Token difficulty profiling
+- Run a reference model at FP16 and record per-token entropy
+- Classify tokens as easy/hard at various thresholds
+- Measure: what % of tokens are easy for different text types?
+
+### Phase 2: Precision sensitivity
+- Compare Q2 vs Q4 vs Q8 output on easy vs hard tokens
+- Measure: does Q2 match Q4 on easy tokens? How much does Q4 help on hard tokens?
+
+### Phase 3: Dynamic switching prototype
+- Implement adaptive precision in MLX or custom Metal
+- Measure: tok/s, perplexity, switching overhead
+
+## Risks
+
+- SSD read latency for loading higher-precision weights may negate speed gains
+- Token-level granularity may be too fine — batch-level or window-level might be more practical
+- Need to store 2 copies of weights (Q2 + Q4), increasing storage requirements

--- a/research/h2-routing-prediction.md
+++ b/research/h2-routing-prediction.md
@@ -1,0 +1,138 @@
+# H2: Expert Routing Prediction + Prefetch
+
+**Status**: Untested
+**Analogy**: CPU branch prediction / instruction prefetch
+**Bottleneck addressed**: Memory capacity (SSD latency hiding)
+
+## The Insight
+
+Modern CPUs don't wait for branch instructions to resolve before fetching the next instruction. Branch predictors guess which way a branch will go and speculatively prefetch instructions along the predicted path. When the prediction is right (~95% of the time), the pipeline never stalls.
+
+MoE models have the same pattern: a router at each layer decides which K experts (out of 64) to activate. That decision takes one forward pass through a small gating network. By the time we know which experts are needed, it's too late to hide the SSD read latency.
+
+## Hypothesis
+
+> If we predict expert routing decisions 2-3 layers ahead using a lightweight predictor, we can prefetch expert weights from SSD while the GPU computes current layers, completely hiding SSD latency.
+
+## Mechanism
+
+```
+Layer N is computing on GPU:
+  1. Lightweight predictor estimates which experts Layer N+2 will need
+     (based on hidden states at Layer N or N-1)
+  2. Prefetch those experts from SSD → RAM in parallel with GPU compute
+  3. By the time Layer N+2 starts, experts are already in RAM
+
+If prediction is wrong:
+  - Fall back to on-demand load (current behavior)
+  - Or serve a low-precision fallback (HOBBIT-style)
+```
+
+## Why This Might Work
+
+Expert routing has strong temporal patterns:
+- The same expert often activates for consecutive tokens
+- Expert activation correlates across nearby layers
+- Certain expert combinations co-occur frequently
+
+Flash MOE observed ~71% OS page cache hit rate, meaning experts are reused. A smart predictor could push this much higher by prefetching before the miss happens.
+
+## Expected Impact
+
+- **Latency hiding**: Overlap 5-7 GB/s SSD reads with GPU compute
+- **Effective throughput**: Close to "all experts in RAM" speed for well-predicted workloads
+- **Flash MOE's key insight was serial GPU/SSD**: This hypothesis challenges that by making prefetch non-blocking via separate threads
+
+## Prior Art (Research Findings)
+
+**This is a very active area** with 12+ serious papers from 2024-2026. Key finding: expert routing is highly predictable, and multiple approaches achieve 93-99% prediction accuracy.
+
+### Cross-Layer Expert Prediction
+
+- **[Pre-Attention Expert Prediction (ETH Zurich, 2025)](https://arxiv.org/abs/2511.10676)**: Predicts experts for layer N from *pre-attention* activations within the same layer (not prior layer output). Just 2 linear layers. **93-97% accuracy** across DeepSeek V2 Lite, Qwen3-30B, Phi-mini-MoE. ~15pp improvement over prior art. Solves the first-layer cold-start problem.
+- **[Fate (2026)](https://arxiv.org/abs/2502.12224)**: Uses cross-layer gate inputs. **97.15% prefetch accuracy**, 99% cache hit rate. Up to 4.5x prefill speedup, 4.1x decode speedup. Previous-layer-only contribution: 78.8% accuracy (the baseline for simple approaches).
+- **[Pre-Gated MoE (Microsoft, ISCA 2024)](https://arxiv.org/abs/2308.12066)**: Adds a pre-gating function one layer ahead. Algorithm-system co-design. Overlaps CPU-to-GPU expert migration with compute.
+
+### Learned Predictors (Trained on Activation Traces)
+
+- **[ProMoE (2024)](https://arxiv.org/abs/2410.22134)**: Trained learned predictor + stride prefetching + chunked prefetching. **2.2x avg speedup** (up to 3.21x) in prefill, **2.07x avg** (up to 5.02x) in decode.
+- **[MoE-Beyond (2025)](https://arxiv.org/abs/2508.17137)**: Lightweight transformer trained on 66M activation traces. **Cache hit rate: 17% → 72%** at only 10% expert cache capacity. 97.5% prediction accuracy on unseen prompts. Most dramatic improvement reported.
+- **[ExpertFlow v1 (2024)](https://arxiv.org/abs/2410.17954)**: Transformer-based predictor predicts *all* experts for entire forward pass at once. Up to 93.72% GPU memory savings, 2-10x speedup.
+- **[ExpertFlow v2 (2025)](https://arxiv.org/abs/2510.26730)**: Adaptive prefetch horizon (not fixed lookahead) based on runtime stats. Model stall time reduced to <0.1% of baseline.
+
+### Shadow Model Approach
+
+- **[OD-MoE (2025)](https://arxiv.org/abs/2512.03927)**: Runs a quantized "shadow" copy of the model in parallel. Shadow runs faster (quantized) and predicts expert activations multiple layers ahead. **FP16 shadow: 99.94% accuracy**, INT8: 97.34%, NF4: 95.67%. Delivers ~75% of fully-GPU-cached speed at 1/3 GPU memory. **Risk**: doubles model memory footprint — may be impractical on 16GB.
+
+### Speculative Decoding + Expert Prefetch Combined
+
+- **[MoE-SpeQ (2025)](https://arxiv.org/abs/2511.14102)**: Uses draft model to *also* predict which experts the full model will need. 4-bit quantized draft achieves >90% prediction accuracy. **Up to 3.3x speedup** on Qwen models. If you're already doing speculative decoding, expert predictions are nearly free.
+
+### Expert Substitution (Handling Prediction Misses)
+
+- **[BuddyMoE (2025)](https://arxiv.org/abs/2511.10054)**: When prefetch fails, substitute a functionally similar "buddy" expert already in memory. Buddy sets built offline using co-activation frequency. Eliminates stalls on misses. **Complementary to any predictor** — prediction + substitution > prediction alone.
+
+### System-Level Scheduling
+
+- **[PreScope (2025)](https://arxiv.org/abs/2509.23638)**: Layer-Aware Predictor + Cross-Layer Scheduling + AsyncIO optimizer. **141% higher throughput**, 74.6% lower latency. Key insight: layer-specific (not generic) predictors + global scheduling across layers.
+- **[DuoServe-MoE (2025)](https://arxiv.org/abs/2509.07379)**: Separates prefill (dense) and decode (sparse) with tailored strategies. **1.42-7.54x latency improvement**. Peak memory only 15% of full model.
+
+### Cache Replacement
+
+- **[SpecMD (2026)](https://arxiv.org/abs/2602.03921)**: Benchmarking study revealing MoE expert access does NOT follow temporal locality (LRU/LFU assumptions fail). Proposes "Least-Stale" eviction. **85x fewer collision misses** vs LRU, 88%+ hit rates at 5% VRAM.
+
+### CPU Branch Prediction Analogy
+
+- **[Speculating Experts (2026)](https://arxiv.org/abs/2603.19289)**: Explicitly draws the branch predictor analogy. Key difference: branch misprediction costs ~15 pipeline cycles; expert load misprediction costs ~10ms of SSD transfer. Stakes are enormously higher — need 97%+ accuracy.
+
+### Key Numbers
+
+| Method | Prediction Accuracy | Speedup | Complexity |
+|--------|-------------------|---------|------------|
+| Previous-layer-only (baseline) | 78.8% | — | Negligible |
+| Pre-attention predictor (ETH) | 93-97% | — | 2 linear layers |
+| Fate (cross-layer gate) | 97.15% | 4.1-4.5x | Low |
+| MoE-Beyond (trained transformer) | 97.5% | 17%→72% hit rate | Medium |
+| ProMoE (learned predictor) | — | 2.07-5.02x | Medium |
+| OD-MoE (NF4 shadow) | 95.67% | ~75% of full-cache | High (memory) |
+| PreScope (layer-aware + scheduling) | — | 141% throughput | Medium |
+
+### Recommended Approach for M4
+
+Based on the literature, the most practical combination:
+1. **Cross-layer linear predictor** (Fate/ETH pre-attention) — run on Metal, minimal overhead
+2. **Async SSD reads** overlapping with GPU compute (PreScope's AsyncIO approach)
+3. **Co-activation table** for expert substitution on miss (BuddyMoE — trivial to implement)
+4. **Least-Stale eviction** instead of LRU (SpecMD finding)
+
+## Open Questions
+
+1. ~~How accurately can we predict routing 2-3 layers ahead?~~ **Answered: 93-97% with 2 linear layers** (ETH Zurich).
+2. Does Apple Silicon's unified memory controller allow true concurrent SSD DMA + GPU compute? Flash MOE says concurrent access hurts by 73%. But **prefetch to RAM staging buffer** might avoid the contention — PreScope's AsyncIO suggests this works.
+3. ~~What's the right predictor architecture?~~ **Answered: 2-layer linear predictor on pre-attention activations** (ETH Zurich) is the sweet spot of accuracy vs overhead.
+4. Can we combine BuddyMoE substitution with HOBBIT mixed-precision fallback for a two-tier miss handling strategy?
+5. Is the SpecMD "Least-Stale" eviction practical on NVMe (designed for GPU VRAM)?
+
+## Experiment Plan
+
+### Phase 1: Routing pattern analysis
+- Run an MoE model and log expert activations per layer per token
+- Measure: cross-layer correlation, temporal locality, expert co-occurrence
+- Answer: how predictable are routing decisions?
+
+### Phase 2: Predictor design
+- Train a small MLP or lookup table on routing traces
+- Measure: prediction accuracy at 1, 2, 3 layer lookahead
+- Determine: minimum accuracy needed for net speedup
+
+### Phase 3: Prefetch pipeline
+- Implement async SSD prefetch on a background thread
+- Test RAM staging buffer approach to avoid GPU memory contention
+- Measure: end-to-end tok/s with prediction + prefetch vs baseline
+
+## Risks
+
+- Prediction accuracy may be too low, wasting SSD bandwidth on wrong experts
+- Unified memory contention may negate prefetch benefits (Flash MOE's finding)
+- Predictor overhead (even small MLP) adds latency per layer
+- RAM staging buffer reduces effective memory for other uses

--- a/research/h3-prompt-aware-loading.md
+++ b/research/h3-prompt-aware-loading.md
@@ -1,0 +1,132 @@
+# H3: Prompt-Aware Weight Pre-Loading
+
+**Status**: Untested
+**Analogy**: Database query planning / query optimization
+**Bottleneck addressed**: Memory capacity (working set optimization)
+
+## The Insight
+
+A database doesn't load every table into memory for every query. The query planner analyzes the SQL, determines which tables and indexes are needed, estimates cardinality, and creates an execution plan that minimizes I/O.
+
+LLM inference does the opposite: it loads the entire model (or hopes the right experts are cached) regardless of the prompt. But different prompts activate very different parts of the model:
+- Code generation heavily uses certain experts/layers
+- Creative writing activates different ones
+- Math reasoning has its own "hot" components
+
+## Hypothesis
+
+> By analyzing the prompt before running full inference, we can predict the model's working set (which experts, layers, or weight subsets will be most active) and pre-load them into RAM, achieving higher cache hit rates and lower latency.
+
+## Mechanism
+
+```
+1. CLASSIFY: Run prompt through a tiny classifier (<100M params)
+   → Output: workload category (code, math, creative, chat, etc.)
+
+2. PLAN: Look up the pre-computed "execution plan" for that category
+   → Which experts are hot for this category
+   → Which layers need full precision
+   → Estimated memory budget
+
+3. PRE-LOAD: Before starting inference, load the predicted working set
+   → Priority-order expert loading from SSD
+   → Evict cold experts from previous workload
+
+4. EXECUTE: Run inference with warm cache
+   → Most expert loads are cache hits
+   → Fall back to on-demand loading for misses
+```
+
+## Why This Might Work
+
+MoE expert activation patterns are known to cluster by task type. Research on expert specialization shows:
+- Some experts "own" specific domains (code, language, reasoning)
+- Expert activation is partially predictable from input features
+- System prompts / few-shot examples strongly predict the overall workload type
+
+On a 24GB machine, we can fit maybe 30-40% of a large MoE model's experts in RAM. If we load the **right** 30-40%, cache hit rates could jump from ~70% to ~90%+.
+
+## Expected Impact
+
+- **Cache hit rate**: 70% → 85-95% for categorized workloads
+- **Latency reduction**: Fewer SSD reads during generation
+- **No quality impact**: We're loading the same weights, just preemptively
+
+## Prior Art (Research Findings)
+
+Multiple groups have worked on this. The building blocks all exist, but the **end-to-end pipeline** (prompt text → classifier → expert loading plan → inference) is an **unexplored combination**.
+
+### Pre-Inference Expert Prediction Systems
+
+- **[SiDA-MoE (MLSys 2024)](https://arxiv.org/abs/2310.18859)**: Closest to our idea. Offline-trained **LSTM hash function** predicts which experts a batch will activate. Runs in a shadow thread concurrent with the previous batch. **3.93x throughput increase**, 72% latency reduction, 80% GPU memory savings, 99%+ prediction accuracy. Key: sparse activation means most experts never activate for a given input type.
+- **[DAOP (DATE 2025)](https://arxiv.org/abs/2501.10375)**: Per-sequence activation patterns predict experts one layer ahead. Non-critical experts offloaded to CPU; predicted experts speculatively pre-calculated on CPU. **Unquantized Mixtral-8x7B: >4.5 tok/s on single A6000**. Key insight: CPU is idle during GPU compute — use it for speculative pre-computation.
+- **[eMoE (2025)](https://arxiv.org/abs/2503.06823)**: Most explicitly "prompt-aware" system. Observes recurring patterns in token-to-expert routing across prompts. Predicts experts **every few prompts** (not every token), because adjacent prompts from the same task use the same experts. **80% memory reduction**, 17% latency reduction. Key finding: coarse-grained periodic prediction is valid — same cached experts work for several consecutive prompts.
+
+### Expert Specialization Evidence
+
+- **["What Gets Activated" (2026)](https://arxiv.org/abs/2601.10159)**: Analyzed three MoE LLMs across three domains. Identified two classes: **domain experts** (preferentially activated for specific domains, lower routing entropy) and **driver experts** (causally influential regardless of domain). Tokens earlier in sentences trigger driver experts more. **Direct evidence that prompt domain → expert activation mapping exists and is identifiable.**
+- **[Input Domain Aware MoE (ACM MM 2025)](https://arxiv.org/abs/2510.16448)**: Routing using probabilistic mixture model trained independently of task objectives. Experts develop stable, interpretable specialization boundaries when routing is decoupled from task training.
+- **[Stanford CS231N 2024](https://cs231n.stanford.edu/2024/papers/do-experts-specialize-a-mechanistic-exploration-of-mixture-of-ex.pdf)**: Sequence-level gating groups experts by topic/discourse. Token-level gating aligns with syntactic categories (nouns vs verbs). Specialization is more syntactic/structural at token level, more semantic at sequence level.
+
+### Temporal Locality and Activation Tracing
+
+- **[MoE-Infinity (2024)](https://arxiv.org/abs/2401.14361)**: Sequence-level expert activation tracing. **Only 3-20% of experts activate at a time, and 30-46% of activated experts are reused within a single sequence**. This temporal locality is the foundation for all prefetching. **4-20x latency reduction** vs baselines.
+
+### Cache Replacement Strategy
+
+- **[SpecMD (2026)](https://arxiv.org/abs/2602.03921)**: MoE expert access does NOT follow temporal locality (LRU/LFU assumptions fail). Access is *periodic and predictable*. "Least-Stale" eviction policy: **85x fewer collision misses** vs LRU, **88%+ hit rates at only 5% VRAM**.
+
+### Key Numbers
+
+| System | Prediction Method | Key Result |
+|--------|------------------|------------|
+| SiDA-MoE | LSTM hash, shadow thread | 3.93x throughput, 99% accuracy |
+| DAOP | Per-sequence patterns | >4.5 tok/s on 90GB unquant model |
+| eMoE | Prior distribution, periodic | 80% memory reduction |
+| MoE-Infinity | Activation tracing | 4-20x latency reduction |
+| SpecMD | Least-Stale eviction | 85x fewer misses vs LRU |
+
+### The Gap
+
+The specific pipeline — **classify prompt domain from raw text → map to predicted expert activation set → pre-load before any inference token is processed** — has not been built. The building blocks exist:
+1. Domain classifiers (trivial with any small model)
+2. Expert specialization maps (arXiv 2601.10159 shows they're identifiable)
+3. Expert offloading infrastructure (MoE-Infinity, DAOP, eMoE)
+
+No paper connects them end-to-end as a pre-inference planning step, analogous to how a database query optimizer uses cardinality estimation to plan page fetches before execution.
+
+## Open Questions
+
+1. ~~How many distinct workload categories are needed?~~ The expert specialization literature suggests domain-level (code, math, creative) is meaningful, plus syntactic categories at token level.
+2. ~~How stable are expert activation patterns within a category?~~ **eMoE confirms**: adjacent prompts from same task use same experts — coarse-grained is fine.
+3. Can we use the system prompt alone (often available before user input) to pre-load?
+4. What's the switching cost when the workload changes mid-conversation?
+5. ~~How do we build the category → expert mapping?~~ **arXiv 2601.10159** provides the method: entropy-based and causal-effect metrics on activation traces.
+6. Can we combine SiDA-MoE's shadow-thread predictor with SpecMD's Least-Stale eviction?
+
+## Experiment Plan
+
+### Phase 1: Expert activation profiling
+- Run diverse prompts (code, math, creative, chat) through an MoE model
+- Record per-expert activation frequency for each category
+- Measure: how distinct are the activation profiles? Is there meaningful clustering?
+
+### Phase 2: Classifier + lookup table
+- Build a lightweight prompt classifier (or use embeddings + k-NN)
+- Map each class to a ranked list of expert priorities
+- Measure: how many top-K experts from the predicted set actually get activated?
+
+### Phase 3: Pre-loading pipeline
+- Implement category-based expert pre-loading before inference starts
+- Measure: cache hit rate improvement, time-to-first-token impact, overall tok/s
+
+### Phase 4: Adaptive refinement
+- Update the lookup table online as we observe actual activations
+- Test: does the system improve over multiple conversations?
+
+## Risks
+
+- Expert activation may not cluster cleanly by prompt type
+- The classification step adds latency to time-to-first-token
+- Mid-conversation topic changes may thrash the cache
+- Building good category profiles requires extensive offline profiling

--- a/research/h4-lowrank-corrections.md
+++ b/research/h4-lowrank-corrections.md
@@ -1,0 +1,156 @@
+# H4: Low-Rank Base + Sparse SSD Corrections
+
+**Status**: Untested
+**Analogy**: Compressed sensing / progressive image rendering
+**Bottleneck addressed**: Memory capacity
+
+## The Insight
+
+Compressed sensing in MRI reconstructs full images from far fewer measurements than the Nyquist rate by exploiting the fact that natural images are sparse in some basis. You don't need all the data — you need the right projection plus a way to fill in the gaps.
+
+LoRA proved that the difference between a pre-trained model and a fine-tuned model lives in a very low-rank subspace — a few matrices of rank 16-64 capture most of the adaptation. This implies that **weight matrices themselves have significant redundant structure**.
+
+Progressive JPEG works similarly: send a coarse version fast, then refine it. The user sees something useful immediately.
+
+## Hypothesis
+
+> Decompose each weight matrix into a low-rank base (fits in RAM) plus sparse corrections (stored on SSD). The base provides a usable approximation for most tokens. Corrections are loaded on-demand only for layers/tokens where the approximation is insufficient.
+
+## Mechanism
+
+```
+Offline (one-time preparation):
+  For each weight matrix W (shape [m, n]):
+    1. Compute SVD: W = U @ S @ V^T
+    2. Keep top-k singular values as BASE = U[:,:k] @ S[:k,:k] @ V[:,:k]^T
+    3. Compute CORRECTION = W - BASE (sparse, most entries near zero)
+    4. Quantize and compress CORRECTION, store on SSD
+    5. Store BASE in RAM (much smaller: m*k + k*n vs m*n)
+
+Inference:
+  1. Run forward pass using BASE weights (fast, all in RAM)
+  2. Monitor output quality signal (entropy, confidence)
+  3. If quality is degraded on certain layers:
+     a. Load CORRECTION for those layers from SSD
+     b. Re-compute: output = x @ (BASE + CORRECTION)
+     c. Continue with corrected activations
+```
+
+## Memory Math
+
+For a 70B model with typical layer dimensions:
+- Full Q4 weights: ~40GB
+- Rank-256 SVD base (Q4): ~8-12GB (5-8x reduction depending on architecture)
+- Corrections (sparse, quantized): ~30GB on SSD
+
+**This could fit a 70B model's working approximation in 24GB RAM.**
+
+## Why This Might Work
+
+- Weight matrices in large LLMs are known to have rapidly decaying singular value spectra
+- LoRA (rank 16-64) captures fine-tuning deltas — the base model's structure is even more compressible
+- The correction is sparse (many near-zero entries) — compresses well on SSD
+- Different layers have different effective ranks — some are nearly low-rank already
+
+## Expected Impact
+
+- **Memory**: 70B model base fits in ~10-12GB RAM
+- **Quality**: Rank-256 base retains ~90-95% of model quality (hypothesis — needs testing)
+- **Speed**: Most inference runs at RAM speed; SSD corrections only for critical layers
+- **Composability**: Combine with KV cache compression (TurboQuant) for full 70B on 24GB
+
+## Prior Art (Research Findings)
+
+This is a very active area. The W = LR + S decomposition is well-validated, but the **end-to-end system** (LR in RAM, S streamed from SSD on demand) has **not been built**.
+
+### SVD-Based LLM Compression
+
+- **[SVD-LLM (ICLR 2025)](https://arxiv.org/abs/2403.07378)**: Truncation-aware SVD with data whitening via Cholesky decomposition. Sequential layer-wise parameter update to compensate accumulated error. **LLaMA-7B at 20% compression: 1.6x inference speedup, >95% accuracy retained, 15 min to compress** (vs 5.5h for ASVD). V2 (NAACL 2025): 28% better perplexity gap, 13% higher accuracy under 7GB budget. [GitHub](https://github.com/AIoT-MLSys-Lab/SVD-LLM)
+- **[ASVD (2023)](https://arxiv.org/abs/2312.05821)**: Activation-aware SVD — rescale weight matrix by activation RMS to absorb outliers before SVD. **10-30% compression without quality loss, 50% KV cache reduction**. Training-free. Slow (5.5h for 7B). [GitHub](https://github.com/hahnyuan/ASVD4LLM)
+- **[AdaSVD (2025)](https://arxiv.org/abs/2502.01403)**: Adaptive per-layer rank allocation. Iterative alternating updates to compensate truncation error without training. **Consistently outperforms SVD-LLM at all compression ratios**. Key finding: early layers and specific MLP layers need higher rank. [GitHub](https://github.com/ZHITENGLI/AdaSVD)
+- **[ResSVD (2025)](https://arxiv.org/abs/2505.20112)**: Two-stage SVD — truncate to rank r1, compute residual, truncate residual to rank r2. **Confirms the "truncation residual" contains recoverable structure** — directly analogous to our "base + correction" idea. Layer-selective compression (avoid early layers) is critical.
+
+### W = Low-Rank + Sparse Decomposition
+
+- **[LoSparse (ICML 2023)](https://arxiv.org/abs/2306.11222)**: First paper to decompose LLM weights as W = LR + S. Sparse component captures large-magnitude outlier weights that degrade low-rank approximation. **Validates the W = LR + S concept.** Limitation: requires full-network fine-tuning.
+- **[HASSLE-free (CPAL 2025)](https://arxiv.org/abs/2502.00899)**: **One-shot (no fine-tuning)** post-training W = S + LR decomposition. Llama3-8B with (2:4 sparse + rank-64): **18% perplexity reduction vs prior methods, 28% accuracy gap reduction**. Joint optimization of S and LR together outperforms applying them independently.
+- **[3BASiL (NeurIPS 2025)](https://arxiv.org/abs/2603.01376)**: ADMM-based algorithm with cross-layer optimization. LLaMA-8B with (2:4 sparse + rank-64): **30% better perplexity gap vs dense, 2.5x faster compression**. [GitHub](https://github.com/mazumder-lab/3BASiL)
+- **[HSS Compression (CODS 2025)](https://arxiv.org/abs/2601.07839)**: Hierarchical sparse separable factorization. Uses Reverse Cuthill-McKee permutation to cluster high-magnitude weights toward diagonal, improving off-diagonal compressibility.
+
+### Quantized + Low-Rank Combined
+
+- **[CALDERA (NeurIPS 2024)](https://arxiv.org/abs/2405.18886)**: Decomposes W = Q + L*R where Q is quantized dense, L/R are low-rank (also quantized). **Outperforms all prior methods below 2.5 bits/parameter**. The low-rank component captures systematic error that quantization alone misses. Conceptually closest to "low-rank base + quantized corrections" — but both components always in memory. [GitHub](https://github.com/pilancilab/caldera)
+- **[SLiM (ICML 2025, NVIDIA)](https://arxiv.org/abs/2410.09615)**: Three-way: quantization + 2:4 sparsity + low-rank adapter (mathematically computed, no training). **5.66% accuracy improvement over prior best, 4.3x layer-wise speedup**.
+
+### System-Level Weight Streaming
+
+- **[Hypura (2026, Apple Silicon)](https://github.com/t8/hypura)**: Storage-tier-aware inference scheduler placing tensors across GPU/RAM/NVMe. Uses `pread()` with `F_NOCACHE`. For dense models: attention+norms stay in GPU RAM, FFN tensors stream from NVMe via prefetch lookahead. **99.5% neuron cache hit rate after warmup.** Closest existing system to "keep compact warm weights in RAM, stream rest from SSD."
+- **[ENDOR (2024)](https://arxiv.org/html/2406.11674v1)**: Hardware-friendly sparse format for SSD-offloaded inference. High compression ratio + low decompression overhead for streaming sparse weights.
+- **[FlashSVD (2025)](https://arxiv.org/abs/2508.01506)**: Fuses low-rank projections directly into FlashAttention and FFN kernels. **70% reduction in peak activation memory**, zero accuracy loss. Shows fused execution of factored weights is viable.
+
+### Singular Value Spectrum Analysis
+
+- Weight matrices show **power-law singular value decay** on log-log plots
+- **"Small singular values matter too"** [(NeurIPS 2025)](https://arxiv.org/abs/2410.17770): Random matrix theory analysis showing departures from Marchenko-Pastur distribution at both large AND small singular values, especially in Q/K/V matrices. Complicates naive truncation.
+- **MLP up/down projections are more compressible than attention matrices**
+- Effective rank: **32-1024 per layer** captures most useful structure (varies by compression ratio)
+
+### Key Numbers
+
+| Method | Decomposition | Quality | Compression | Notes |
+|--------|--------------|---------|-------------|-------|
+| SVD-LLM | Truncated SVD | >95% accuracy | 20-60% | Data whitening critical |
+| HASSLE-free | S + LR (one-shot) | 18% better PPL gap | 2:4 sparse + rank-64 | No fine-tuning |
+| 3BASiL | S + LR (ADMM) | 30% better PPL gap | 2:4 sparse + rank-64 | Cross-layer optimization |
+| CALDERA | Q + LR (quantized) | SOTA below 2.5 bpw | Variable | Both terms in memory |
+| SLiM | Q + sparse + LR | +5.66% accuracy | 4.3x speedup | NVIDIA hardware |
+| Hypura | Tiered streaming | 99.5% cache hit | — | Apple Silicon native |
+
+### The Gap
+
+The end-to-end system — **decompose W = LR + S, keep LR in unified memory, stream S from SSD selectively** — has not been assembled. Components exist:
+1. High-quality decomposition algorithms (HASSLE-free, 3BASiL, CALDERA)
+2. System-level streaming (Hypura for Apple Silicon)
+3. Execution kernels for factored weights (FlashSVD)
+4. Sparse storage formats for SSD (ENDOR)
+
+The connection is missing. For M4 with ~19GB usable: a 70B model's LR component (40-60% of original) could fit in RAM, with the S sparse corrections streamed from NVMe for layers being processed.
+
+## Open Questions
+
+1. ~~What rank captures "enough" of each layer?~~ **Partially answered**: ranks 32-1024 per layer, MLP more compressible than attention, early layers need higher rank (AdaSVD).
+2. How do we decide when corrections are needed? ResSVD's two-stage approach suggests always applying corrections is better than selective.
+3. ~~Can we combine low-rank base with quantization?~~ **Yes — CALDERA does exactly this** (W = Q + LR) and outperforms all methods below 2.5 bpw.
+4. ~~What's the overhead of SVD decomposition?~~ SVD-LLM: 15 min for 7B (vs 5.5h for ASVD). 3BASiL: 2.5x faster than prior S+LR methods.
+5. ~~Is the correction actually sparse enough to compress well?~~ **Yes** — LoSparse, HASSLE-free confirm sparse components are real and compressible.
+6. Can Hypura's tiered storage approach be extended to stream LR vs S components rather than full layers?
+
+## Experiment Plan
+
+### Phase 1: Spectral analysis
+- Take a 7B model, compute SVD of each weight matrix
+- Plot singular value decay curves by layer type and depth
+- Measure: what rank retains 90%, 95%, 99% of the Frobenius norm?
+
+### Phase 2: Quality at reduced rank
+- Run inference with rank-truncated weights (rank 64, 128, 256, 512)
+- Measure: perplexity vs rank for different layer types
+- Identify which layers are most sensitive to rank reduction
+
+### Phase 3: Correction sparsity
+- Compute W - BASE at various ranks
+- Measure: sparsity ratio, compression ratio, distribution of correction magnitudes
+- Determine: optimal storage format for corrections (CSR, block-sparse, quantized dense)
+
+### Phase 4: End-to-end prototype
+- Implement low-rank base in RAM + SSD correction loading
+- Test selective correction strategies
+- Measure: tok/s, perplexity, memory usage
+
+## Risks
+
+- If singular values decay slowly, the base won't be much smaller than the full matrix
+- Correction loading from SSD may add too much latency
+- SVD preparation is expensive (hours for large models)
+- Accumulated errors from rank truncation across 80+ layers may compound
+- Different architectures (GQA, MQA) may have different compressibility

--- a/research/h5-layer-lod.md
+++ b/research/h5-layer-lod.md
@@ -1,0 +1,144 @@
+# H5: Layer LOD — Variable Precision by Depth
+
+**Status**: Untested
+**Analogy**: Game engine Level of Detail (LOD)
+**Bottleneck addressed**: Memory capacity + bandwidth
+
+## The Insight
+
+In 3D game engines, objects close to the camera are rendered with high-polygon meshes (high detail) while distant objects use simplified meshes (low detail). The player never notices because visual importance decreases with distance. This saves massive amounts of GPU computation and memory.
+
+Transformer layers have a similar property: **not all layers contribute equally to output quality**. Research on layer pruning shows:
+- Early layers (embedding, first few transformers) build fundamental representations — high impact
+- Late layers (final few before output head) shape the distribution over tokens — high impact
+- Middle layers are often redundant — experiments show you can skip or compress many of them with minimal quality loss
+
+## Hypothesis
+
+> By assigning higher precision (Q8/Q4) to the first and last N layers and aggressive compression (Q2/Q1) to middle layers, we can fit significantly larger models in RAM while maintaining output quality.
+
+## Mechanism
+
+```
+Layer allocation for a 70B model (80 layers):
+
+  Layers 0-9   (first 10):  Q4  — 5GB  (high detail, close to input)
+  Layers 10-69 (middle 60): Q2  — 12GB (low detail, "far away")
+  Layers 70-79 (last 10):   Q4  — 5GB  (high detail, close to output)
+  Embeddings + output head:  Q6  — 2GB  (critical)
+
+  Total: ~24GB — fits in RAM!
+```
+
+Compare to uniform Q4 (40GB) or uniform Q2 (17GB + quality loss).
+
+## Why This Might Work
+
+Multiple lines of evidence suggest middle layers are over-parameterized:
+
+1. **Layer pruning studies**: Removing 30-50% of middle layers from LLMs degrades perplexity by only 1-3 points
+2. **Layer distillation**: Middle layers can be distilled into fewer layers with minimal loss
+3. **Residual connections**: The residual stream carries information past middle layers, reducing their marginal contribution
+4. **Cosine similarity**: Hidden states between adjacent middle layers have very high cosine similarity (~0.99), suggesting incremental changes
+
+## Expected Impact
+
+- **Memory**: 70B model fits in ~24GB with mixed Q4/Q2 allocation
+- **Quality**: Better than uniform Q2, close to uniform Q4 (because critical layers keep precision)
+- **Bandwidth**: Mixed precision reduces total bytes read per token
+- **No SSD needed**: If the model fits in RAM, we avoid SSD latency entirely
+
+## Prior Art (Research Findings)
+
+**The U-shaped importance pattern is confirmed** across multiple independent studies. This is one of the most well-validated hypotheses. Existing tools already support it.
+
+### Direct Confirmation of U-Shape
+
+- **[Layer-Sensitive Quantization (2025)](https://arxiv.org/html/2503.06518v1)**: Measured per-layer quantization sensitivity across Llama, Mistral, Qwen, Gemma. **"Sensitivity spikes tend to be present at the start and end layers."** Pattern holds across datasets, quant methods, bit-widths, and fine-tuned variants. SensiBoost/KurtBoost methods give extra bits to boundary layers: **up to 9% perplexity reduction at 3-bit with only 2% additional memory**.
+- **[Variable Layer-Wise Quantization (2024)](https://arxiv.org/html/2406.17415v1)**: Used LIM (Layer Input Modification) and ZD (Z-score Distribution) metrics. **"The first and the last layer are the most two important layers. Lesser important layers tend to be towards halfway of middle and end."** Llama-2-13B: 30 layers at 4-bit, 10 layers at 2-bit (3.5 avg bpw). Performance stable until 25-50% of layers at lower precision (vs 5-10% with random ordering).
+
+### Layer Pruning Evidence
+
+- **[ShortGPT (ACL 2025)](https://arxiv.org/html/2403.03853v3)**: Block Influence (BI) metric — cosine similarity between layer input/output. **Most-removed layers concentrated in upper-middle** (Llama-2-7B: layers 27, 26, 25, 28...; Llama-2-13B: layers 33, 31, 32, 30...). "Redundancy is primarily manifested in the middle to later layers." **Removing 25% of parameters retains ~91.6% performance** on Llama-2-13B. Up to 55% of layers prunable on multiple-choice tasks.
+- **[Reassessing Layer Pruning (2024)](https://arxiv.org/html/2411.15558v1)**: Simply removing the final 25% of layers outperformed BI and Taylor methods (**52.68% vs 40.80% accuracy**). But lm_head must be tuned after pruning — the output projection is separately critical.
+
+### Two-Phase Model of Layer Function
+
+- **[Attend First, Consolidate Later (BlackboxNLP 2024)](https://arxiv.org/html/2409.03621v1)**: Manipulation experiments on 4 LLMs. **Early layers (~first 50-70%): information-gathering phase** — corrupting hidden states causes catastrophic loss. **Late layers (~top 30-50%): internal-processing phase** — replacing with random vectors causes "small to negligible drop." Pattern: early layers critical, large middle-to-late stretch is robust, final output projection separately important.
+
+### Task-Dependent Layer Roles (Caveat)
+
+- **[Demystifying Layer Roles (2025)](https://arxiv.org/abs/2510.02091)**: **Retrieval/knowledge: concentrated in shallow layers** (ablating early layers causes -0.8 accuracy). **Reasoning: distributed across mid-to-deep layers** (GSM8K sensitive to layers 6, 23, 35 on Qwen3-8B). **Warning: the importance pattern is task-dependent** — not a uniform U-shape for all capabilities. Likelihood-based evaluations (multiple choice) make middle layers appear more dispensable than they are for generation tasks.
+
+### Existing Tools That Support Per-Layer Quantization
+
+| Tool | Per-Layer Support | Platform | Notes |
+|------|------------------|----------|-------|
+| **llama.cpp / GGUF** | Regex-based per-tensor quantization | All | Q2_K already uses Q4_K for attention.vw + feed_forward.w2. Can be manually specified. |
+| **EXL2 / ExLlamaV2** | Automatic per-matrix bit allocation | NVIDIA | Measures quant error per-matrix against calibration data. Closest practical implementation to LOD. |
+| **[mlx-optiq](https://mlx-optiq.pages.dev/)** | KL-divergence sensitivity per layer | **Apple Silicon** | Greedy knapsack solver assigns optimal per-layer bit-widths. **Qwen3.5-0.8B: 2.3x better accuracy than uniform 4-bit, -2% speed penalty**. |
+| **MLX native** | Mixed 3/4/6/8-bit per layer | Apple Silicon | Common practice: 6-bit embeddings, 4-bit body. |
+| **[AutoRound (Intel, 2025)](https://github.com/intel/auto-round)** | Mixed-precision in minutes | All | Exports to GGUF, GPTQ, AWQ. |
+| **[CoopQ (2025)](https://arxiv.org/html/2509.15455)** | Shapley values for inter-layer interactions | All | **20-80% perplexity reduction** vs best baseline at sub-4-bit. Accounts for layer interaction effects. |
+| **[LSAQ (2024)](https://arxiv.org/html/2412.18135v1)** | Jaccard similarity metric | All | Cheapest metric (no gradients). High Jaccard = layer barely changes tokens = lower precision OK. Outperformed uniform in 90% of cases. |
+
+### Key Numbers
+
+| Finding | Evidence | Source |
+|---------|----------|--------|
+| U-shape confirmed | "Sensitivity spikes at start/end layers" | arxiv 2503.06518 |
+| 9% PPL improvement | Protecting boundary layers at 3-bit, 2% extra memory | arxiv 2503.06518 |
+| 25% layers removable | 91.6% performance retained | ShortGPT |
+| 55% layers removable | On multiple-choice tasks | ShortGPT |
+| Middle-to-late layers most redundant | BI metric, cosine similarity ~0.99 | ShortGPT |
+| mlx-optiq 2.3x accuracy improvement | vs uniform 4-bit, on Apple Silicon | mlx-optiq |
+| CoopQ 20-80% PPL reduction | vs best baseline at sub-4-bit | arxiv 2509.15455 |
+
+### Practical Recommendation for M4
+
+**Immediately actionable** — three paths require no custom code:
+1. **llama.cpp regex quant**: Manually assign Q4_K to first/last N layers, Q2_K to middle. Tooling exists.
+2. **mlx-optiq**: Automatic calibration-driven per-layer allocation on Apple Silicon. Compare its bit assignments to the U-shape hypothesis.
+3. **LSAQ Jaccard metric**: Cheapest to implement (no gradients), apply to any GGUF model.
+
+## Open Questions
+
+1. ~~What's the optimal precision allocation? Is it really U-shaped?~~ **Confirmed U-shaped** across multiple models (arxiv 2503.06518, 2406.17415).
+2. ~~Does the optimal allocation depend on the task?~~ **Yes** — retrieval/knowledge needs early layers, reasoning needs mid-to-late layers (arxiv 2510.02091). A single U-shaped allocation may not be optimal for all tasks.
+3. ~~Can we determine the allocation automatically?~~ **Yes** — mlx-optiq (KL-divergence), CoopQ (Shapley values), LSAQ (Jaccard similarity) all do this.
+4. How does this interact with GQA? Attention heads may have different sensitivity than FFN.
+5. What about MoE models — should expert layers get different LOD than attention layers? (JANG from H1 suggests attention at 8-bit, experts at 2-3 bit.)
+6. Can we combine LOD quantization with layer streaming (H5 + Approach 8 from Agents.md) — keep first/last layers in RAM at Q4, stream middle layers from SSD at Q2?
+
+## Experiment Plan
+
+### Phase 1: Layer sensitivity profiling
+- Take a 7B model, quantize one layer at a time to Q2 while keeping others at Q4
+- Measure per-layer perplexity impact
+- Plot sensitivity curve by layer depth
+
+### Phase 2: Block sensitivity
+- Group layers into blocks of 5-10
+- Quantize each block to Q2 while keeping others at Q4
+- Measure: which blocks can tolerate Q2 without significant quality loss?
+
+### Phase 3: Optimal allocation search
+- Test several allocation patterns:
+  - Uniform Q4 (baseline)
+  - Uniform Q2 (lower bound)
+  - U-shaped (Q4 edges, Q2 middle)
+  - Gradient (Q4 → Q3 → Q2 → Q3 → Q4)
+  - Sensitivity-guided (per-layer based on Phase 1)
+- Measure: perplexity vs total memory for each allocation
+
+### Phase 4: Large model deployment
+- Apply best allocation to 70B model
+- Measure: does it fit in 24GB? Perplexity vs uniform quantization?
+- Test across multiple tasks (code, math, creative, chat)
+
+## Risks
+
+- The U-shaped hypothesis may be wrong — sensitivity could be uniform or erratic
+- Perplexity may not capture real quality differences (some layers may be critical for specific capabilities like math)
+- Mixed-precision dequantization is more complex — may need separate Metal kernels per precision level
+- GGUF format may not support per-layer quantization (need custom format or MLX)

--- a/research/h6-activation-sparsity.md
+++ b/research/h6-activation-sparsity.md
@@ -1,0 +1,176 @@
+# H6: Activation Sparsity Prediction
+
+**Status**: Untested
+**Analogy**: Frustum culling in game engines / sparse matrix computation
+**Bottleneck addressed**: Memory bandwidth + compute
+
+## The Insight
+
+In 3D game engines, "frustum culling" skips rendering objects outside the camera's view frustum. You don't compute pixels for things the player can't see. This eliminates 50-90% of rendering work in typical scenes.
+
+Transformer FFN layers have a parallel property: **most neuron activations are near zero for any given input**. After the gating function (SiLU/SwiGLU), a large fraction of intermediate values are near-zero or exactly zero. The matmul `output = activation @ W_down` computes a full dot product, but most terms contribute almost nothing.
+
+If we could predict which neurons will activate strongly **before** loading their weights, we could skip loading and computing the near-zero ones entirely.
+
+## Hypothesis
+
+> By predicting which FFN neurons will have significant activations and only loading/computing those rows, we can reduce effective model size and bandwidth requirements by 50-80% per layer.
+
+## Mechanism
+
+```
+Standard FFN:
+  gate = x @ W_gate        # [hidden] @ [hidden, intermediate] → [intermediate]
+  up   = x @ W_up          # [hidden] @ [hidden, intermediate] → [intermediate]
+  act  = SiLU(gate) * up   # [intermediate] — many values near zero
+  out  = act @ W_down      # [intermediate] @ [intermediate, hidden] → [hidden]
+
+Sparse FFN:
+  1. PREDICT: Which neurons will be active?
+     - Small predictor: x @ W_predict → top-K neuron indices
+     - Or: threshold on W_gate's first few rows
+
+  2. LOAD: Only fetch rows of W_gate, W_up for predicted active neurons
+     - And corresponding columns of W_down
+     - From SSD if offloaded, or skip memory read if in RAM
+
+  3. COMPUTE: Matmul with sparse subset only
+     - [hidden] @ [hidden, K] instead of [hidden, intermediate]
+     - K << intermediate (e.g., 2048 vs 14336)
+```
+
+## Why This Might Work
+
+Strong empirical evidence for FFN activation sparsity:
+
+1. **SiLU/SwiGLU gating**: The gating function naturally zeros out ~50-70% of neurons
+2. **PowerInfer (SJTU)**: Demonstrated that activation sparsity is predictable — same neurons tend to activate for similar inputs. Achieved 11x speedup on consumer GPUs.
+3. **DejaVu (2023)**: Showed that activating only 5% of MLP neurons gives 95%+ of model quality for many inputs
+4. **ReLU models**: Some architectures use ReLU which produces exact zeros. Even smoother activations (SiLU) have practical sparsity.
+5. **MoE is coarse-grained sparsity**: MoE activates K out of N experts. This is fine-grained sparsity within a single expert/FFN.
+
+## Expected Impact
+
+- **Bandwidth**: Read 20-50% of FFN weights per layer instead of 100%
+- **Memory**: Only active neuron weights need to be in RAM (rest on SSD)
+- **Compute**: Proportional reduction in matmul operations
+- **Composability**: Stacks with quantization — Q4 on 30% of neurons < Q4 on 100%
+
+## Quantifying the Savings
+
+For a 70B model, FFN weights are ~70% of total parameters:
+- Full Q4 FFN weights: ~28GB
+- At 30% activation rate: ~8.4GB effective
+- Combined with Q2: ~4.2GB effective
+- Plus attention weights (~12GB Q4): total ~16-20GB — **fits in 24GB**
+
+## Prior Art (Research Findings)
+
+**Extensively researched area**. Activation sparsity is real, predictable, and exploitable. The critical variable is activation function: ReLU models have 85-95% native sparsity; SiLU/SwiGLU models need modification.
+
+### ReLU vs SiLU/SwiGLU — The Fundamental Tradeoff
+
+| Activation | Native Sparsity | Skip Computation? | Notes |
+|-----------|----------------|-------------------|-------|
+| ReLU | 85-95% (OPT, GPT) | Yes — exact zeros | Older architectures |
+| SiLU/SwiGLU | ~0% native | Only with threshold | Llama, Qwen, Mistral |
+| dReLU (TurboSparse) | 85-90% after fine-tune | Yes — hard zeros | Requires fine-tuning |
+| ReLU2 | ~70% | Yes | `max(0,x)^2`, nearly no perf loss |
+
+**"Sparsing Law"**: ReLU models improve in sparsity with more training data; SiLU models show the opposite trend.
+
+### PowerInfer (v1 and v2)
+
+- **[PowerInfer (2023)](https://arxiv.org/abs/2312.12456)** | [GitHub](https://github.com/SJTU-IPADS/PowerInfer): Exploits power-law distribution in neuron activation frequency. "Hot neurons" (consistently active) preloaded to GPU; "cold neurons" stay on CPU/SSD. Small trained MLP predicts per-token/per-layer which cold neurons activate. **OPT-175B on RTX 4090: 13.20 tok/s avg, 29.08 peak. Up to 27.8x speedup** over llama.cpp under memory-constrained offload.
+- **[PowerInfer-2 (2024)](https://arxiv.org/abs/2406.06282)**: Extended to smartphones. TurboSparse-Mixtral-47B (~90% sparsity, only ~3-4B params active from 47B): **11.68 tok/s on smartphone (19GB)**, 2.13 tok/s at 7GB. For 7B models: ~40% memory savings vs llama.cpp.
+
+### Deja Vu — Contextual Sparsity
+
+- **[Deja Vu (2023)](https://arxiv.org/abs/2310.17157)** | [GitHub](https://github.com/FMInference/DejaVu): Lightweight 2-layer MLP predictor per layer. **Key trick: lookahead prediction** — input to attention layer k predicts MLP sparsity for layer k, hiding predictor latency in the pipeline. OPT-175B: **~85% total sparsity, no accuracy drop at 75% sparsity, 2x speedup** vs FasterTransformer. Predictor overhead: 18.1% of compute time. Focused on ReLU models (OPT series).
+
+### Training-Free Approaches (No Fine-Tuning Required)
+
+- **[TEAL (ICLR 2025)](https://arxiv.org/abs/2408.14690)** | [GitHub](https://github.com/FasterDecoding/TEAL): Magnitude-based thresholding on hidden states. No training, no predictor, no architecture change. **Works on SiLU/SwiGLU models (Llama-2, Llama-3, Mistral). 40% sparsity: near-zero degradation. 50% sparsity: 1.53-1.80x wall-clock speedup.** Universally applicable but sparsity is lower than ReLUfied models.
+- **[SparseInfer (DATE 2025)](https://arxiv.org/abs/2411.12692)**: Predicts activation by comparing **only sign bits** of inputs and weights. For ReLU, you only need sign of `W^T x` to predict if neuron fires. **Predictor overhead: negligible (<0.1% runtime)**. Orders of magnitude cheaper than MLP predictors.
+- **[ActTail (2025)](https://arxiv.org/abs/2603.12272)**: Non-uniform sparsity allocation using Heavy-Tailed Self-Regularization theory. **At 80% sparsity: 21.8% better perplexity than TEAL** on LLaMA-2-7B, 40.1% on LLaMA-2-13B. Different layers tolerate different sparsity levels.
+
+### Training Sparsity Into Models
+
+- **[TurboSparse (2024)](https://arxiv.org/abs/2406.05955)**: Replaced SiLU with novel `dReLU` via continued training. **TurboSparse-Mistral-7B: 90% neuron inactivity per layer. TurboSparse-Mixtral-47B: 85% per expert FFN.** Decoding speedup: 2-5x. On PowerInfer-2: 11 tok/s on mobile phone.
+- **[ProSparse (2024)](https://arxiv.org/abs/2402.13516)**: ReLU + progressive sparsity regularization with sine-curve schedule. **LLaMA2-7B: 89.32% sparsity, LLaMA2-13B: 88.80%.** Performance comparable to original SwiGLU versions.
+- **[ReLU Strikes Back (ICLR 2024)](https://openreview.net/forum?id=osoWxY8q2E)**: Simple ReLU substitution on LLaMA achieves ~67% sparsity without fine-tuning.
+- **[ReLU2 (2024)](https://arxiv.org/abs/2402.03804)**: `max(0,x)^2` achieves 70% sparsity with nearly no performance loss at 1.3B scale.
+
+### Dense-to-MoE Conversion (Coarser Granularity)
+
+- **[CMoE (2025)](https://arxiv.org/abs/2502.04416)**: Training-free dense→MoE conversion. Analyzes activation rates to split neurons into shared (always-active) and routed (dynamic) experts. **Conversion under 5 minutes. 1.4-1.6x end-to-end speedup.**
+- **[ExpertWeaver (2026)](https://arxiv.org/abs/2602.15521)**: Exploits GLU gating patterns. Identifies "universal neurons" vs "specialized neurons". Training-free, outperforms CMoE, FLAP, LLM-Pruner.
+
+### Batch Size Matters
+
+- **[Polar Sparsity (NeurIPS 2025)](https://arxiv.org/abs/2505.14884)**: At large batch sizes, union of active MLP neurons approaches full density, eliminating gains. **Attention head sparsity is stable across batch sizes while MLP sparsity is not.** For single-user inference (batch=1, our M4 case): MLP sparsity works perfectly. Up to 2.2x speedup.
+
+### Apple Silicon / Metal Hardware
+
+- **No native sparse GEMM** for neural network patterns on Apple Silicon. M4 uses ARM SME with 512-bit registers, 16x16 MAC arrays — dense matmul accelerator.
+- **Metal has no cuSPARSE equivalent**. Sparse texture/buffer support exists (memory allocation, not compute skipping).
+- **Implementation must be custom Metal kernel**: gather active neuron rows → dense matmul on subset. At batch=1, this is purely memory-bandwidth-bound — skipping inactive weight rows saves time proportional to sparsity ratio.
+- A 90%-sparse model loading only 10% of FFN weight bytes = 10x reduction in FFN bandwidth = direct throughput gain at batch=1.
+
+### Key Numbers
+
+| Method | Sparsity | Speedup | Quality Impact | Training? |
+|--------|----------|---------|---------------|-----------|
+| PowerInfer (OPT-175B) | Model-dependent | 13-29 tok/s | Negligible | No (profiling only) |
+| Deja Vu (OPT-175B) | 85% | 2x | None at 75% | Yes (predictor) |
+| TEAL (Llama/Mistral) | 40-50% | 1.53-1.80x | Near-zero at 40% | No |
+| TurboSparse (Mistral-7B) | 90% | 2-5x | Maintained | Yes (fine-tune) |
+| ProSparse (LLaMA2-7B) | 89.32% | — | Comparable | Yes (fine-tune) |
+| CMoE | Structural | 1.4-1.6x | Minimal | No (5 min) |
+| SparseInfer | ReLU only | ~20% over SOTA | Within 1% | No |
+
+### Recommended Path for M4
+
+1. **Immediate (no training)**: Apply **TEAL thresholding** to existing Llama/Qwen checkpoints. 40-50% sparsity, 1.5-1.8x speedup. Custom Metal kernel for gather-based sparse GEMV.
+2. **Quick conversion (5 min)**: **CMoE/ExpertWeaver** dense-to-MoE conversion on existing checkpoints. 1.4-1.6x speedup.
+3. **If we control model choice**: Use **TurboSparse variants** (already available on HuggingFace). 85-90% sparsity with PowerInfer-style hot/cold placement.
+4. **Optimal predictor**: **SparseInfer sign-bit prediction** for ReLUfied models — negligible overhead, very accurate.
+
+## Open Questions
+
+1. ~~How accurate does the predictor need to be?~~ DejaVu: 93-99% across layers is achievable and sufficient.
+2. ~~What's the right predictor architecture?~~ **SparseInfer (sign-bit)** for ReLU models (negligible overhead), **TEAL (magnitude threshold)** for SiLU models (no predictor needed).
+3. ~~What's the overhead of prediction vs savings?~~ DejaVu: 18% overhead. SparseInfer: <0.1% overhead. TEAL: zero overhead (just thresholding).
+4. ~~Does this work with attention?~~ **Yes** — Polar Sparsity shows attention head sparsity is exploitable and stable across batch sizes.
+5. Can we combine TEAL thresholding with LOD quantization (H5) — variable sparsity + variable precision by layer?
+6. What's the actual Metal kernel speedup for gather-based sparse GEMV vs dense on M4? Need to benchmark the irregular access pattern overhead.
+
+## Experiment Plan
+
+### Phase 1: Activation analysis
+- Run a 7B model and record FFN activations for diverse prompts
+- Measure: sparsity ratio, distribution of activation magnitudes, which neurons are "always on" vs "input-dependent"
+- Plot: activation heatmaps by layer and neuron
+
+### Phase 2: Predictability
+- For each layer, train a simple predictor (linear or small MLP) on (input hidden state → active neuron mask)
+- Measure: prediction accuracy (precision, recall) at various sparsity thresholds
+- Determine: can we predict top-K active neurons reliably?
+
+### Phase 3: Quality at various sparsity levels
+- Force-sparsify FFN layers to 50%, 30%, 20%, 10% active neurons
+- Measure: perplexity degradation at each level
+- Test: predicted sparsity vs random sparsity vs oracle (true top-K)
+
+### Phase 4: Sparse inference prototype
+- Implement sparse matmul in Metal (gather active rows → dense matmul on subset)
+- Measure: actual speedup on M4 GPU, accounting for gather overhead
+- Compare: sparse Q4 vs dense Q2 (which gives better quality per byte?)
+
+## Risks
+
+- Metal may not efficiently handle the irregular memory access patterns of sparse computation
+- Prediction overhead could eat into speedup, especially for small models
+- Activation sparsity patterns may be model-specific — what works for Llama may not work for Qwen
+- Need to train predictors per model (not a one-time effort)
+- Block-sparse may be needed for GPU efficiency, but reduces theoretical sparsity benefit


### PR DESCRIPTION
## Summary

Six novel research hypotheses for running large LLMs on constrained Apple Silicon hardware, each drawing analogies from other CS fields. Every hypothesis includes extensive prior art research (50+ papers total), key numbers, gap analysis, and experiment plans.

- **H1: Adaptive precision per token** — Q2 for easy tokens, Q4+ for hard ones. ~80% of tokens are "easy". FlexQuant/EAD show 1.3-2.7x speedup potential.
- **H2: Expert routing prediction + prefetch** — Predict expert needs 2-3 layers ahead. 12+ papers, ETH Zurich achieves 93-97% accuracy with just 2 linear layers.
- **H3: Prompt-aware weight pre-loading** — Analyze prompt → pre-load likely experts. SiDA-MoE gets 3.93x throughput. Building blocks exist, end-to-end pipeline is the gap.
- **H4: Low-rank base + sparse SSD corrections** — SVD base in RAM, corrections on SSD. CALDERA achieves SOTA below 2.5 bpw. Decomposition solved, system integration is the gap.
- **H5: Layer LOD — variable precision by depth** — U-shaped importance confirmed across multiple studies. mlx-optiq already works on Apple Silicon. **Most immediately actionable.**
- **H6: Activation sparsity prediction** — TEAL gives 1.5-1.8x training-free on existing models. PowerInfer achieves 27.8x with neuron profiling. CMoE converts dense→MoE in 5 minutes.

## Recommended priority

1. **H5** (Layer LOD) — test today with mlx-optiq or llama.cpp regex quant
2. **H6** (Activation sparsity) — apply TEAL thresholding, try CMoE conversion
3. **H2** (Routing prediction) — implement cross-layer linear predictor for MoE expert prefetch
4. **H1/H3/H4** — longer-term explorations with novel system-building needed

## Test plan

- [x] All hypothesis pages include: hypothesis, mechanism, prior art, key numbers, gap analysis, open questions, experiment plan
- [x] README updated with prior art summary and actionability ratings
- [ ] Run first experiments using H5 (mlx-optiq) and H6 (TEAL) approaches

🤖 Generated with [Claude Code](https://claude.com/claude-code)