### PR TITLE
H9-E2: KV quantization at workload context lengths (#36)

### DIFF
--- a/dev/active/issue-36-h9-e2-kv-quant/context.md
+++ b/dev/active/issue-36-h9-e2-kv-quant/context.md
@@ -1,0 +1,54 @@
+# H9-E2 — Context / Findings
+
+**Issue:** #36 | **Branch:** `experiment/h9-e2-kv-quant-workload-context`
+
+## Current state
+- Phase 0 setup complete: branch created, docs scaffolded.
+- Plan drafted (`plan.md`), under automated plan-review loop.
+
+## Environment (verified)
+- MLX 4-bit model cached: `mlx-community/Qwen3-30B-A3B-4bit` (`~/.cache/huggingface`).
+- GGUF cached: `models/gguf/Qwen3-30B-A3B-Q4_K_M.gguf` (19 GB) — for Arm (b) only.
+- `mlx_lm` 0.31.1; `generate_step`/`stream_generate` accept `kv_bits`, `kv_group_size`,
+  `quantized_kv_start` (see `mlx_lm/generate.py:303`, `maybe_quantize_kv_cache:295`).
+- MLX GPU counters available: `mx.get_active_memory`, `mx.get_peak_memory`,
+  `mx.reset_peak_memory` — used to isolate the KV-cache delta.
+- Reusable: `h9_e1_baseline.py` (phys_footprint RUSAGE_INFO_V2 collector,
+  `build_prompt_of_length`, `engine_generate_timed`), `experiment_utils.log_experiment`.
+
+## Baselines being compared against
+- H7 (PR #20): kv4/group64 = zero PPL loss, 3.56× compression — but tiny model, short ctx.
+- E1 (#35): MLX-wired 30B = 16.55 GB phys_footprint; loads only on a quiesced machine.
+- E1b (#42): mmap resident ~4 GB, tool-call 90%; concurrent decode not demonstrable on the
+  contended host → Arm (b) prerequisite unmet.
+
+## Implementation
+- `scripts/h9_e2_kv_workload.py` implemented (`smoke` + `run` subcommands).
+  - Deterministic synthetic multi-speaker transcripts (seeded by sample index, no RNG/clock).
+  - **Direct KV-cache sizing via `sum(c.nbytes)`** (gate metric) + analytic cross-check
+    (hard 25% validity gate). Verified analytic ratio = **3.56×** (matches H7 exactly).
+  - kv4 routes through `make_prompt_cache` + `maybe_quantize_kv_cache(quantized_kv_start=0)`;
+    asserts every entry is `QuantizedKVCache`. Teacher-forced summary-only ΔPPL through the
+    same incremental cached path (so quantized K/V actually participate).
+  - Two-stage memory preflight (pre-load total vs post-load incremental; no weight
+    double-count). kv16-OOM-at-15K path: memory PASS-with-asterisk, quality = unverified.
+  - ruff clean; analytic/rouge unit-checks pass.
+
+## Findings
+- **Machine-contention blocker hit (expected):** free RAM at implementation time = **10.9 GB**,
+  below the ~18 GB the MLX-wired 30B (16.55 GB) needs. The sweep is an **idle-machine**
+  experiment by design — the script's preflight aborts rather than thrash (E1 lesson). The
+  measurement runs (`smoke`, then `run`) must be executed on a **quiesced machine** (quit
+  Cursor/Chrome/extra Claude procs) per [h9-machine-contention-blocker]. No measured E2
+  numbers yet; code + gates are ready to run.
+- _(Phase B/C results to fill in after the quiesced sweep.)_
+
+## Review stats
+- Plan review rounds: **6** (12 findings addressed; converged round 6 — all remaining items
+  already covered).
+- Code review rounds: _tbd_
+- Findings addressed: _tbd_
+
+## Next steps
+- On a quiesced machine: `uv run python scripts/h9_e2_kv_workload.py smoke` (compat gate),
+  then `uv run python scripts/h9_e2_kv_workload.py run` (full sweep). Fill in findings + verdict.

--- a/dev/active/issue-36-h9-e2-kv-quant/context.md
+++ b/dev/active/issue-36-h9-e2-kv-quant/context.md
@@ -44,11 +44,33 @@
 - _(Phase B/C results to fill in after the quiesced sweep.)_
 
 ## Review stats
-- Plan review rounds: **6** (12 findings addressed; converged round 6 — all remaining items
-  already covered).
-- Code review rounds: _tbd_
-- Findings addressed: _tbd_
+- **Plan review rounds: 6** — 12 findings addressed; converged round 6 (reviewer confirmed all
+  remaining items already covered). Key hardening: summary-only teacher-forced ΔPPL (not
+  prompt-swamped); `.nbytes` as the exact per-GB gate metric with a hard 25% analytic-validity
+  gate; two-stage memory preflight (no weight double-count); kv16-OOM-at-15K verdict split
+  (memory PASS-with-asterisk, quality unverified); verdict scoped to the 24 GB off-hours tier.
+- **Code review rounds: 3** — converged round 3 (no material findings). Findings addressed:
+  - R1 (4 medium): chunked prefill (512) with interleaved quantization to match mlx_lm
+    `generate_step` production semantics; ΔPPL paired by `sample_idx`; `per_gb_pass=None` when
+    both configs skipped; realized-seq analytic basis; split `n_kv16/kv4_samples`.
+  - R2 (1 **high** + 1 medium): **the high was a real correctness bug** — the prompt builder
+    trimmed the already-templated token sequence, stripping the assistant generation suffix so
+    the model would continue an unfinished user turn instead of summarizing (silently
+    invalidating the whole experiment). Fixed: trim the transcript *body* and re-apply the
+    chat template (verified: hits exact target tokens with `<|im_start|>assistant` suffix
+    preserved). Medium: force `per_gb_pass=False` on `memory_inconclusive`.
+  - R3 (1 low): a both-skipped length no longer drags a clean result down from
+    PASS_WITH_ASTERISK to PARTIAL.
+- **Total findings addressed: 12 (plan) + 8 (code, incl. 1 high) = 20.**
 
-## Next steps
-- On a quiesced machine: `uv run python scripts/h9_e2_kv_workload.py smoke` (compat gate),
-  then `uv run python scripts/h9_e2_kv_workload.py run` (full sweep). Fill in findings + verdict.
+## Run status / blocker
+- Code is complete and verified (ruff clean; prompt-builder and verdict-logic unit-checked).
+- **Measurement sweep NOT yet run** — free RAM 10.9 GB < ~18 GB needed for the MLX-wired 30B.
+  This is the documented [machine-contention blocker], identical to E1/E1b. The sweep is an
+  idle-machine experiment by design; the script's preflight aborts rather than thrash.
+
+## Next steps (on a quiesced machine — quit Cursor/Chrome/extra Claude procs)
+1. `uv run python scripts/h9_e2_kv_workload.py smoke` — kv4 compatibility gate (asserts the
+   quantized path is engaged, not a no-op).
+2. `uv run python scripts/h9_e2_kv_workload.py run` — full sweep (3 lengths × {kv16,kv4} × 5).
+3. Fill in findings + verdict here; close the issue / update the PR with measured numbers.

--- a/dev/active/issue-36-h9-e2-kv-quant/plan.md
+++ b/dev/active/issue-36-h9-e2-kv-quant/plan.md
@@ -1,0 +1,337 @@
+# H9-E2 — KV quantization at workload context lengths
+
+**Issue:** #36 | **Branch:** `experiment/h9-e2-kv-quant-workload-context`
+**Depends on:** H7 (PR #20, kv4 validated at short ctx), E1 (#35 / PR #40), E1b (#41 / PR #42)
+
+## Hypothesis
+
+H7 validated `kv_bits=4, kv_group_size=64` with **zero perplexity loss**, but only on a
+tiny model (24-layer, 896-hidden) at **short contexts**. The external claim is that KV
+quantization overhead amortizes past ~4K tokens. The H9 daily workload that *drives* the
+long-context requirement is **call-transcript summarization** (30–60 min calls ≈ 8–15K
+tokens). E2 confirms H7's kv4 result holds at the **real workload context lengths
+(10K / 12K / 15K)** on the actual Tier-1 model (Qwen3-30B-A3B) before E3/E5 adopt kv4 as
+the default config, and quantifies the **effective context-per-GB** improvement.
+
+## Scope — two arms (per the issue's 2026-06-12 rescope comment)
+
+The E1 reframe split Tier 1 into **off-hours/batch** (MLX-wired, idle machine) and
+**concurrent/daily-driver** (llama.cpp mmap, under ballast). E2 has one arm per mode.
+
+### Arm (a) — Off-hours MLX tier (idle machine) — **primary, this PR**
+MLX `kv_bits=4, kv_group_size=64` vs `kv_bits=16` baseline on Qwen3-30B-A3B-4bit, idle
+machine, summarizing 10K / 12K / 15K-token call transcripts. This is the direct H7
+re-validation at workload context lengths and the experiment the success gates are written
+against. **Runs independently on an idle machine** — no E1b dependency.
+
+### Arm (b) — Concurrent llama.cpp tier (under ballast) — **conditional, scoped but gated**
+llama.cpp `-ctk q8_0` (and `-ctv q4_0` if stable on Metal) under 8 GB competing ballast,
+mmap mode, where KV-cache pages compete with expert pages in the page cache. The issue
+rescope says Arm (b) **should run after E1b (#41) confirms the mmap baseline passes
+co-residency gates**. E1b's verdict (PR #42, recorded in
+`research/h9-agentic-ops-stack.md`) was **CONDITIONAL / inconclusive on speed**: mmap
+resident set ✓ (~4 GB) and tool-call quality ✓ (90%), but **decode under ballast was not
+demonstrable** on the contended dev machine and **full Metal offload is GPU-OOM-blocked**.
+Because the E1b concurrent-decode baseline never cleared its gate on this host, **Arm (b)
+cannot produce a gate-eligible KV-quant result yet** — its blocker is the same host
+contention, not KV quant. Decision below; default is to **defer Arm (b)** and ship Arm (a)
+as the E2 deliverable, with the Arm-(b) driver wired but explicitly marked not-yet-eligible.
+
+## What changes vs H7 (single-variable discipline)
+
+| Axis | H7 (PR #20) | E2 Arm (a) |
+|---|---|---|
+| Model | tiny (24L / 896h, n_kv_heads=2) | **Qwen3-30B-A3B-4bit** (real Tier-1 model) |
+| Context | short (≤ ~hundreds of tokens) | **10K / 12K / 15K** |
+| KV configs | fp16 / kv8 / kv4 | **kv16 baseline vs kv4 (`group_size=64`)** |
+| Quality metric | 4-domain perplexity | summarization spot-check + perplexity-on-transcript |
+| Memory metric | RSS + peak_gpu_mb | **phys_footprint** (standing methodology) + MLX peak GPU |
+
+The model, context, and quality task all change at once vs H7 — so E2 is **"does the kv4
+verdict transfer to the real model at real context lengths,"** not a pure single-variable
+swap. We log the model SHA + MLX version so the comparison is reproducible.
+
+## Pinned configuration (gates are not reproducible without this)
+
+All Arm (a) runs use these fixed parameters; every value is logged into the `config` block
+of each `experiments.jsonl` record.
+
+| Param | Value | Why |
+|---|---|---|
+| Model | `mlx-community/Qwen3-30B-A3B-4bit` (already cached) | Tier-1 model; same as E1 |
+| Runtime | in-process `mlx_lm` 0.31.1 (`stream_generate`) | KV quant is an mlx_lm.generate kwarg; no server needed for a quality/memory probe. **Scope note (plan-review R5-R3-medium):** the issue says "vllm-mlx Tier 1 stack from E1," but the engine tier is the right place to isolate KV-quant quality+memory without HTTP/batching confounds (and vllm-mlx wires the same mlx_lm KV path). This experiment therefore **validates the mlx_lm engine tier**; the **verdict is capped accordingly** — "kv4 validated in-process; vllm-mlx served overhead (HTTP, continuous batching, server memory layout) is a follow-up before adopting kv4 as a *served* default." If time permits on the passing config, a short vllm-mlx served confirmation run is logged as a bonus (not a gate). |
+| Context lengths | **10240, 12288, 15360** tokens (prompt) | The issue's 10K/12K/15K workload regime |
+| KV configs | **A: `kv_bits=None` (fp16 baseline)**; **B: `kv_bits=4, kv_group_size=64`** | The H7 comparison, at workload ctx |
+| `quantized_kv_start` | **0** | Quantize from the first token so the full prompt KV is quantized — this is the memory-relevant regime for a prefill-dominated summarization workload (a non-zero start would leave the bulk of a 15K prompt in fp16 and understate compression). H7 used the builtin default; we pin 0 explicitly and log it. |
+| `max_tokens` (summary len) | **256** | Representative summary length; pinned for comparable prefill/decode split |
+| Sampling | greedy (`temp=0`) | Deterministic; removes sampler variance from quality + tok/s |
+| Samples per length | **5** call-transcript prompts | Issue: "spot-check on 5 samples per length" |
+| Memory metric | **phys_footprint** (process tree, `proc_pid_rusage` RUSAGE_INFO_V2) + MLX `get_peak_memory` / `get_active_memory` | Standing H9 methodology: phys_footprint replaces RSS. MLX GPU counters isolate the **KV cache delta** (see below). |
+
+## Transcript inputs (real-or-synthetic, reproducible)
+
+The issue allows "real or synthetic meeting transcripts." Real call transcripts are PII and
+not in-repo, so we **generate synthetic multi-speaker meeting transcripts** deterministically
+(fixed seed via index, **no `Math.random`/`Date.now`** — varied by sample index) covering
+realistic ops content (quarterly planning, customer escalation, eng standup, sales pipeline
+review, hiring debrief). Each is token-trimmed to the exact target length using the model
+tokenizer (`build_prompt_of_length` pattern from `h9_e1_baseline.py:284`). The summarization
+instruction is a fixed prefix. We log the generator seed + the realized token count per
+sample so inputs are reproducible. Transcripts are written under the experiment `logs/` dir
+for inspection. **Limitation logged:** synthetic transcripts are coherent but not real call
+data; the spot-check measures *relative* kv4-vs-kv16 degradation, which is robust to input
+realism even if absolute quality is not call-representative.
+
+## Measurement — isolating the KV cache (the core number)
+
+The headline gate is **effective context per GB of KV cache**, so we must measure the **KV
+cache memory specifically**, not just total footprint (which is dominated by the ~16.5 GB of
+model weights and would swamp a KV delta of a few hundred MB).
+
+**Method — analytic KV size is the PRIMARY gate metric; a steady-state GPU-counter reading
+is the cross-check (plan-review R1-medium):** the naive `peak_active − baseline_active` delta
+captures transient prefill buffers, graph/compiler allocations, and scratch — it does **not**
+cleanly isolate the KV cache and would *inflate* it. So we invert the original framing:
+
+1. Load model. `mx.eval()` to force materialization; record baseline `mx.get_active_memory()`
+   (weights + framework, no cache).
+2. **Direct cache `.nbytes` = the gate metric (verified API, plan-review R5-R2).** After
+   prefill, each cache entry is a `KVCache` (kv16) or, with `quantized_kv_start=0`, a
+   **`QuantizedKVCache`** (verified: `maybe_quantize_kv_cache` calls `c.to_quantized(...)` once
+   `c.offset >= quantized_kv_start`). Both expose a **`.nbytes` property** — so the KV-cache
+   size is read **directly and exactly** as `sum(c.nbytes for c in prompt_cache)`, not inferred
+   from allocator deltas. This is the gate metric. We **cross-check** against the analytic
+   formula `kv16 bytes = 2 (K+V) × n_layers × n_kv_heads × head_dim × seq_len × 2 (fp16)` and
+   kv4 ≈ kv16/3.5 (group_size=64 + per-group scale/bias; matches H7's 3.56×). Model dims come
+   from the loaded config (`n_layers`, `n_kv_heads`, `head_dim`), logged per record.
+   **Assertion (plan-review R5-R2-medium):** in the kv4 runs, assert every cache entry
+   `isinstance(c, QuantizedKVCache)` after prefill — if any entry is unquantized, the kv4 path
+   did not engage → `status=infra_fail_kv_quant_unsupported` (not a quality result).
+3. **Steady-state GPU-counter cross-check (not the gate):** build a `prompt_cache` via
+   `make_prompt_cache(model)`, run `stream_generate` with the pinned KV config over the full
+   prompt + `max_tokens`, then **`mx.eval()` and read `get_active_memory()` while the
+   populated cache is still retained** — `cache_resident_active − baseline_active` is the
+   steady-state cache footprint (measured *after* prefill scratch is freed, not a peak delta).
+   `mx.get_peak_memory()` is recorded **separately, only for total-budget / OOM monitoring**.
+4. **`.nbytes`-vs-analytic agreement is a HARD VALIDITY GATE (plan-review R2-R2-medium):**
+   validate agreement on the **Phase A controlled run first**. The direct `.nbytes` figure is
+   the per-GB gate metric; the analytic formula is the cross-check. If they diverge > 25%
+   (unexpected — both are exact-ish), the cell is **`status=memory_inconclusive`** and we
+   investigate before trusting the ratio. The GPU-counter steady-state delta (point 3) is an
+   additional sanity check on total allocation but is **not** the per-GB number now that
+   `.nbytes` gives the cache size directly. A cell counts as a clean per-GB PASS when `.nbytes`
+   and analytic agree within 25% AND the ratio ≥ 1.5×.
+5. **phys_footprint** of the process tree is logged at baseline and peak for the standing
+   methodology and as the total-memory budget check — but the **per-GB gate uses the analytic
+   KV-cache figure** (cross-checked by the steady-state delta), since that is what kv4 shrinks.
+
+**Effective context per GB** = `context_tokens / kv_cache_GB`, computed per (length, config).
+Gate: `(tokens/GB)_kv4 / (tokens/GB)_kv16 ≥ 1.5×` at each length. (H7's 3.56× compression
+predicts ~3.5× here; the 1.5× gate has comfortable headroom, and a result far below 3.5×
+would itself be a finding about large-model KV layout.)
+
+## Quality measurement (no measurable degradation gate)
+
+Per the issue ("ROUGE or manual spot-check on 5 samples per length"):
+1. **Teacher-forced PPL on the SUMMARY-TOKEN POSITIONS ONLY (primary, automatable) — same
+   tokens under both configs (plan-review R3-R1-medium):** PPL is only comparable if both
+   configs score the **identical** token sequence, and it must measure the quantity that
+   actually matters — the summary distribution, not the prompt. So: pin **one target per
+   prompt = the kv16-generated summary** (generated first; deterministic under greedy). Run
+   the full sequence (transcript prompt + summary) teacher-forced under each KV config, but
+   **compute NLL/PPL over the summary-token positions only** (conditioned on the full
+   transcript via the KV cache). A 10–15K prompt would otherwise swamp a 256-token summary and
+   hide any degradation — so the gate uses **summary-only ΔPPL**. The full-sequence /
+   transcript PPL is kept as a **diagnostic** but is not the gate. Scoring target text + its
+   token count logged per record. Per-length mean **summary-token ΔPPL (kv4 − kv16)**; gate:
+   **|ΔPPL| ≤ 1% relative** (matching H7's "zero loss").
+
+   **Scoring MUST route through the quantized cache (plan-review R5-R2-medium) — else the gate
+   proves nothing.** A naive single full-sequence forward pass builds a *fresh* default
+   (fp16) cache and would report identical PPL for both configs, silently not testing kv4. So
+   the scoring run **reuses the generation cache path**: prefill the transcript into a
+   `prompt_cache`, apply `maybe_quantize_kv_cache(..., kv_bits=4, kv_group_size=64,
+   quantized_kv_start=0)` so the cache becomes `QuantizedKVCache`, then **teacher-force the
+   pinned summary tokens one step at a time through `model(token, cache=prompt_cache)`**,
+   accumulating NLL over the summary positions — the same incremental path `generate_step`
+   uses, so the quantized K/V actually participate. **Assert** `isinstance(c, QuantizedKVCache)`
+   for every entry before scoring the kv4 variant; if not, the PPL gate is
+   **infrastructure-invalid** (`status=infra_fail_kv_quant_unsupported`) and we fall back to
+   the generated-summary ROUGE-L + manual spot-check as the quality signal, logged as such.
+2. **ROUGE-L between kv4 and kv16 summaries (secondary):** with greedy decoding, kv16 and
+   kv4 should produce near-identical summaries if quantization is lossless. Compute ROUGE-L
+   of kv4-summary vs kv16-summary (kv16 as reference) per sample. ROUGE-L ≈ 1.0 = no
+   degradation. `rouge-score` is a tiny pure-Python dep; if unavailable we fall back to
+   token-level exact-match ratio + normalized edit distance and log the method.
+3. **Manual spot-check artifact:** the 5×3 = 15 summary pairs (kv16, kv4) are written to
+   `logs/summaries/` for human inspection; context.md records a one-line spot-check verdict
+   per length.
+
+**Gate composition (plan-review R6-low — ROUGE-L is brittle for generated text):** the
+**formal quality gate is teacher-forced ΔPPL ≤ 1% relative** at each length (the rigorous,
+metric-stable signal), **plus the manual spot-check showing no degradation**. ROUGE-L is a
+**divergence trigger, not a hard gate**: if mean ROUGE-L(kv4 vs kv16) drops **below 0.90** at
+any length, that flags the spot-check for closer human review at that length (small lexical
+differences under greedy can lower ROUGE without real quality loss). The quality gate
+**PASSES** when ΔPPL is within noise at all three lengths and the spot-check finds no
+degradation, with no OOM at 15K; a low ROUGE-L escalates review but does not by itself fail
+the gate.
+
+## Success Gates (from the issue)
+
+| Gate | Target | Source metric |
+|---|---|---|
+| Summarization quality holds at 10K/12K/15K | no measurable degradation vs kv16 | **ΔPPL ≤ 1% rel (formal) + spot-check**, per length; ROUGE-L < 0.90 triggers extra review but is not itself a fail (plan-review R6) |
+| Effective context per GB | **≥ 1.5×** vs kv16 | analytic KV-cache GB is the gate metric **only while it agrees with the measured steady-state delta within 25%** (hard validity gate); on > 25% divergence the cell is `memory_inconclusive` and the gate falls back to the **measured** delta (plan-review R2-R2-medium) |
+| No OOM / degradation at 15K | kv4 completes 15K without OOM | run completes; phys_footprint logged |
+| Speed amortization (reporting, non-blocking) | kv4 prefill/decode not materially slower than kv16 | median prefill tok/s, decode tok/s, TTFT per (L,cfg); **flag if kv4 is >10% slower** than kv16 at any length (plan-review R2 — the amortization hypothesis is about overhead; flagged, not a hard fail) |
+
+## Method
+
+### Phase A — De-risk (smoke test, idle machine)
+1. Confirm idle machine (quit Cursor/Chrome/extra Claude procs per the
+   [machine-contention blocker](../../../memory note)); log `get_available_memory_gb()`.
+   MLX-wired 30B is ~16.5 GB — it loads fine **only** on a quiesced machine (E1 lesson).
+2. **Per-length analytic preflight — explicit budget basis, no double-counting
+   (plan-review R2-medium, R5-R1-medium):** the comparison must not double-count weights.
+   Two clearly-separated checks:
+   - **Pre-load (total-budget) check:** measured **once, before loading the model**, against a
+     fixed usable cap. `total_required(L,cfg) = weights (~16.55) + analytic_KV(L,cfg) +
+     scratch (~2) + safety (~1)` vs **usable cap ~19–21 GB** (idle 24 GB host). This is the
+     "could the whole thing fit at all" gate.
+   - **Post-load (incremental-headroom) check:** measured **after the model is loaded**, where
+     weights are already resident. Compare only the **incremental** need
+     `analytic_KV(L,cfg) + scratch + safety` against **post-load** `get_available_memory_gb()`
+     (which already reflects the resident weights). This avoids charging the 16.55 GB twice.
+   A run proceeds only if **both** checks pass; otherwise skip, log
+   `status=skipped_oom_preflight` with **both total footprint and incremental headroom**
+   logged. The 15K **kv16** baseline is the highest-risk cell (largest fp16 KV); it gets its
+   own gate (see below).
+3. Load `mlx-community/Qwen3-30B-A3B-4bit`; record baseline active GPU mem + phys_footprint.
+4. **kv4 compatibility gate (plan-review R3-medium) — verify quantization is real, not a
+   silent no-op:** run a short and a medium prompt under kv16 and kv4, and confirm kv4
+   **actually changes the cache representation and memory slope** — i.e. the steady-state
+   cache delta grows ~3.5× more slowly with seq_len under kv4 than kv16 (a measurable slope
+   difference between the short and medium points), and the cache objects are
+   `QuantizedKVCache`. If kv4 does **not** change the memory slope, MLX's quantized-KV path is
+   unsupported/broken for this model+version → classify as **INFRASTRUCTURE FAILURE**
+   (`status=infra_fail_kv_quant_unsupported`), not a model-quality failure, and stop. This
+   distinguishes "kv4 doesn't help" from "kv4 isn't actually engaged."
+5. **Empirical per-length preflight (plan-review R1-medium) — analytic budget is planning
+   input, not sufficient proof:** for each length L, before the 5-sample sweep, build the
+   **prompt cache only** (prefill, no long decode) under the run's config, `mx.eval()`, and
+   record peak MLX memory + phys_footprint. Proceed to the full sweep for (L, config) **only
+   if observed headroom ≥ ~1 GB** vs `get_available_memory_gb()`; otherwise log
+   `status=skipped_oom_empirical` with the observed peak. This catches allocator
+   fragmentation, tokenizer/input buffers, attention workspaces, and dual-cache overlap that
+   the analytic estimate omits — the kv16 12K/15K cells are the tight ones on this host.
+   **Log the per-cell expected budget breakdown before each launch** (plan-review R4-low):
+   `weights ~16.55 + analytic_KV(L,cfg) + scratch ~2 + safety ~1` → expected total. Reference
+   figures: analytic kv16 KV ≈ 1.41 GiB at 15K (~0.40 GiB kv4) → kv16 15K ≈ 20.96 GB total,
+   kv4 15K ≈ 19.95 GB — both borderline on a 24 GB host, viable only genuinely idle. The
+   logged budget makes a skip self-explaining.
+6. Checkpoint to context.md before the full sweep.
+
+**kv16-OOM reporting path — verdict split by gate (plan-review R2-medium, R3-R3-medium):** if
+the **15K kv16** baseline OOMs/fails preflight while **15K kv4 completes**, that is **not** an
+E2 failure — it is a *positive* demonstration of kv4's value (kv4 fits where kv16 cannot). But
+the two gates at 15K must be reported **separately**, because a missing kv16 baseline means
+there is nothing to compare quality against:
+- **Memory / per-GB gate at 15K = PASS-with-asterisk:** per-GB computed against the
+  **analytic** kv16 size (well-defined even if kv16 can't physically run); verdict states
+  "kv16 15K not physically runnable on this 24 GB host; kv4 15K runs — strongest form of the
+  per-GB result."
+- **Quality gate at 15K = `unverified`** — without a kv16 15K summary there is no teacher-
+  forced ΔPPL or ROUGE comparison; we do **not** claim "no degradation vs kv16" at 15K.
+  Quality is proven only at the lengths where both configs ran (10K/12K).
+The **overall verdict** then reads explicitly: "quality proven through 12K; 15K quality
+unverified (kv16 OOM); kv4 memory advantage demonstrated at all three lengths." Logged
+distinctly from a clean both-run PASS.
+
+### Phase B — KV sweep (the experiment)
+For each length L ∈ {10240, 12288, 15360} and each config C ∈ {kv16, kv4}:
+1. Generate the 5 synthetic transcript prompts for L (fixed per index), tokenizer-trimmed.
+2. For each sample: fresh `prompt_cache`; `reset_peak_memory()`; `stream_generate` with C;
+   record prefill tok/s, decode tok/s, TTFT, generated summary, KV-cache GPU delta, peak
+   phys_footprint. Compute perplexity-on-transcript under C.
+3. Aggregate per (L, C): median prefill tok/s, median decode tok/s, mean PPL, KV GB.
+4. Write summaries to `logs/summaries/`.
+
+### Phase C — Analysis + gates
+1. Per length: ΔPPL (kv4−kv16), ROUGE-L(kv4 vs kv16), effective-context-per-GB ratio.
+2. Evaluate the three gates. Record PASS/FAIL per gate per length.
+
+### Phase D — Verdict + logging
+1. Log one `experiments.jsonl` record **per (length, config)** via `log_experiment`
+   (`mem_method=phys_footprint`), full pinned config in `config`, gate results in `results`,
+   plus a summary record with the per-GB ratios and overall verdict. Required project fields
+   per record (value or `null`+explicit reason string, plan-review R4-low):
+   - `gpu_memory_mb` — MLX peak active memory (`get_peak_memory`) for the run.
+   - `cache_hit_rate` — `null`, `cache_hit_rate_reason: "not applicable: no expert/page cache
+     in the MLX KV-quant arm"`.
+   - `perplexity` — the pinned-target PPL value under the run's KV config.
+   - `kv_cache_gb_analytic` (gate metric) + `kv_cache_gb_measured` (steady-state cross-check).
+2. **Verdict is scoped to the 24 GB off-hours MLX tier (plan-review R1-medium):** this Arm (a)
+   validates MLX-wired Qwen3-30B-A3B on an **idle 24 GB M4 Pro** (~19–21 GB usable). It does
+   **not** clear the original CLAUDE.md 16 GB / ~10–11 GB-usable daily-driver budget — at
+   ~16.5 GB weights the model does not even fit that budget. The verdict must state "validated
+   for the 24 GB off-hours MLX tier; the 16 GB daily-driver budget is the concurrent-tier
+   question (mmap/offload/streaming — E1b/E3/E5), not addressed here." kv4 *helps* a 16 GB
+   target but is not *sufficient* for it; that is not in scope.
+3. Verdict classes:
+   - **PASS** — quality holds at all 3 lengths AND per-GB ≥ 1.5× at all 3 lengths AND no OOM
+     at 15K. → E3/E5 adopt `kv_bits=4, kv_group_size=64` as default for the **24 GB off-hours
+     tier**.
+   - **PARTIAL** — passes at 10K/12K but degrades or OOMs at 15K. → kv4 default capped at the
+     passing context; note the ceiling for E3.
+   - **FAIL** — measurable degradation or < 1.5× per-GB at workload lengths. → kv4 not adopted
+     as default; record the negative result (valuable — contradicts the H7-extrapolation).
+
+### Arm (b) decision (recorded, not silently skipped)
+Arm (b)'s prerequisite — a clean E1b concurrent-decode baseline — **did not clear its gate on
+this host** (E1b verdict: decode-under-ballast not demonstrable; GPU-OOM on full offload).
+Therefore Arm (b) **cannot yield a gate-eligible KV-quant number** until the host can be
+genuinely quiesced for a partial-offload baseline. **Default plan: defer Arm (b)**; ship
+Arm (a) as E2's deliverable; leave the llama.cpp `-ctk q8_0 / -ctv q4_0` driver wired but
+labeled *exploratory, not PASS-eligible* (mirrors E1b's Q4_K_S handling). If the user wants
+Arm (b) attempted opportunistically on a quiesced machine, the driver supports it; any
+numbers it produces are logged with `gate_eligible=false` and the same host-contention caveat
+E1b carried. This keeps E2's verdict honest and unblocked rather than waiting on the #41 host
+blocker.
+
+## Risks / failure modes
+
+- **30B won't load co-resident** (E1's failure): Arm (a) is an **idle-machine** experiment by
+  design; we gate on `get_available_memory_gb()` ≥ ~18 GB before loading and abort with a
+  clear message otherwise (do not thrash). The machine-contention blocker memory applies.
+- **KV delta is too small to measure cleanly** against 16.5 GB of weights: handled by using
+  MLX GPU counters (which isolate allocations) + the analytic cross-check; the analytic
+  figure is the documented fallback gate metric.
+- **`quantized_kv_start` semantics:** pinned to 0 and logged; if mlx_lm requires a non-zero
+  warmup before quantizing, we record the realized quantized-fraction and adjust the analytic
+  baseline accordingly (still report the honest measured compression).
+- **ROUGE not deterministic across configs even when lossless** (greedy should make them
+  near-identical): if kv4 and kv16 greedy summaries diverge token-for-token, that **is** a
+  degradation signal at that length, not a metric artifact — reported as such.
+- **15K exceeds model trained context / KV OOM:** Qwen3-30B-A3B supports ≥ 32K context, so
+  15K is in-range; if KV OOM occurs under kv16 it is itself the finding (kv4 is what avoids
+  it) — logged, not hidden.
+
+## Rollback / non-destructive notes
+
+- E2 adds one driver script (`scripts/h9_e2_kv_workload.py`) and reuses
+  `h9_e1_baseline.py` (phys_footprint collector, `build_prompt_of_length`,
+  `engine_generate_timed`) and `experiment_utils.py` (`log_experiment`,
+  `get_available_memory_gb`, `get_environment_info`). No behavior change to existing scripts.
+- Uses the already-cached MLX 4-bit model; downloads nothing. Synthetic transcripts and
+  summaries are written under the experiment `logs/` dir only.
+
+## Definition of done
+
+**Scope of this PR = Arm (a) only (plan-review R5-low).** Arm (b) is explicitly a
+**follow-up / out-of-scope** here (blocked on the E1b host-contention baseline); its driver
+may be wired but its numbers are not gate-eligible and do not gate this PR.
+
+Done when: pass/fail verdict **per length for Arm (a)** in this context file +
+`experiments.jsonl`; PR merged; issue closed. PASS → E3/E5 default to kv4 (off-hours tier).
+Arm-(b) status recorded as a follow-up with its host-contention caveat (does not block DoD).

--- a/dev/active/issue-36-h9-e2-kv-quant/tasks.md
+++ b/dev/active/issue-36-h9-e2-kv-quant/tasks.md
@@ -21,10 +21,11 @@
 - [x] Arm (b): documented as deferred/out-of-scope (E1b host blocker)
 
 ## Phase 3 — Code review
-- [ ] Commit WIP
-- [ ] Automated code-review loop
+- [x] Commit WIP
+- [x] Automated code-review loop (3 rounds; converged; 8 findings incl. 1 high fixed)
 
 ## Phase 4 — Finalize
-- [ ] Update context.md (findings + review stats)
-- [ ] Commit `Fixes #36`
-- [ ] `gh pr create`
+- [x] Update context.md (findings + review stats)
+- [x] Commits reference #36
+- [x] `gh pr create`
+- [ ] Run the sweep on a quiesced machine; record measured verdict (blocked: 10.9 GB free)

--- a/dev/active/issue-36-h9-e2-kv-quant/tasks.md
+++ b/dev/active/issue-36-h9-e2-kv-quant/tasks.md
@@ -1,0 +1,30 @@
+# H9-E2 — Tasks
+
+## Phase 0 — Setup
+- [x] Validate issue #36, read H9 doc + rescope comment
+- [x] Create branch `experiment/h9-e2-kv-quant-workload-context`
+- [x] Scaffold `dev/active/issue-36-h9-e2-kv-quant/{plan,context,tasks}.md`
+
+## Phase 1 — Plan + review
+- [x] Draft plan.md
+- [x] Automated plan-review loop (6 rounds, 12 findings addressed)
+- [x] User approval
+
+## Phase 2 — Implementation (Arm a, primary)
+- [x] `scripts/h9_e2_kv_workload.py` — synthetic transcript generator (10K/12K/15K, seeded)
+- [x] KV-cache sizing via direct `.nbytes` (gate) + analytic cross-check (3.56× verified)
+- [x] Quality: summary-only teacher-forced ΔPPL + ROUGE-L(kv4 vs kv16), write summaries to logs/
+- [ ] Phase A smoke test **on quiesced machine** (blocked: 10.9 GB free < ~18 GB needed)
+- [ ] Phase B sweep: 3 lengths × {kv16, kv4} × 5 samples (quiesced)
+- [ ] Phase C gates: ΔPPL, ROUGE-L, effective-context-per-GB ≥ 1.5×
+- [ ] Phase D log to experiments.jsonl + verdict
+- [x] Arm (b): documented as deferred/out-of-scope (E1b host blocker)
+
+## Phase 3 — Code review
+- [ ] Commit WIP
+- [ ] Automated code-review loop
+
+## Phase 4 — Finalize
+- [ ] Update context.md (findings + review stats)
+- [ ] Commit `Fixes #36`
+- [ ] `gh pr create`

--- a/research/h9-agentic-ops-stack.md
+++ b/research/h9-agentic-ops-stack.md
@@ -184,7 +184,50 @@ E1**, where RSS *under*-counted MLX's wired memory (0.37 GB reported vs 16.55 GB
   default until a clean partial-offload decode number clears ≥ 12 tok/s. E3 should benchmark
   partial-offload, not full Metal offload, and gate memory on **resident_size**, not phys_footprint.
 
-## Plan Revision (post-E1 researcher response, 2026-06-12)
+## E2 Co-residency Note (June 2026, issue #36 / PR #43) — quantifying the headroom wall
+
+While setting up E2 (KV-quant at workload context), we tried to launch the off-hours MLX arm
+on the **actual working dev machine** and hit the E1 wall again — but this time we measured
+the memory-reclamation levers directly, which sharpens the "headroom, not capacity" thesis
+into operational numbers. Worth recording because it's the constraint every interactive H9
+experiment runs into, and it changes *how* we schedule the off-hours runs.
+
+### The arithmetic that can't be tuned away
+On 24 GB with the user's normal session live (Cursor ~4 GB across its 3 processes, the
+Claude Code agent + its Python child ~1.7 GB, Chrome, openclaw-gateway, etc.):
+- Free/available memory hovered at **9.5–10.6 GB**.
+- MLX-wired 30B needs **~18 GB** (16.55 GB weights wired + KV + scratch).
+- Gap ≈ **7–8 GB**. This is not a tuning problem — `16.55 GB wired + ~6 GB un-quittable
+  working set > 24 GB`. It is the E1 finding restated as an inequality.
+
+### What the reclamation levers actually buy (measured, not assumed)
+- **Trimming Chrome extensions** (disabled a redundant ad-blocker + Grammarly/Loom):
+  Chrome RSS 5.9 → 4.6 GB (**−1.3 GB**), but `available` moved 9.5 → 10.0 GB (**+0.5 GB**).
+  The OS quietly re-absorbed most of the freed pages. App-RSS trimming is largely a mirage
+  for clearing headroom under existing pressure.
+- **`sudo purge`** (flush compressor + inactive/file-backed pages): `available` 10.0 → 10.6 GB
+  (**+0.6 GB**); compressor 2.7 → 2.1 GB. The compressor was holding *needed* pages, not
+  stale junk, so it freed little. purge is not a substitute for closing apps.
+- **The un-measured ~4 GB**: `used` (13 GB) exceeds the sum of quittable app RSS (~11 GB). The
+  remainder is **compressor-occupied (~2 GB) + wired kernel/GPU**, none of it reclaimable while
+  the working set is live. A deep swap history (34M swapouts, 3.2 GB swap in use) confirms the
+  machine has been under sustained pressure.
+- **The biggest single lever is the one we can't pull mid-session: quit Cursor (~4 GB) and
+  run from a bare terminal** — because the Claude Code session itself runs *inside* Cursor's
+  integrated terminal, so the agent driving the experiment is part of the competing working
+  set it's trying to make room for. This is the practical reason the off-hours arm must be run
+  detached, not from the dev session.
+
+### Operational consequence (folds into the standing methodology)
+The off-hours/batch tier is not just "machine idle" as a soft preference — it is a **hard
+launch precondition: the orchestrating IDE/agent session must itself be closed**, and the run
+launched from a standalone terminal (or scheduled overnight). On this machine, no combination
+of extension-trimming + `purge` closes the 7–8 GB gap while Cursor + the agent are live; only
+quitting them does. E2's driver (`scripts/h9_e2_kv_workload.py`) encodes this defensively —
+its two-stage preflight aborts with a clear message rather than thrash (the E1 failure mode)
+when free RAM is below the weights+KV+scratch budget. **No measured E2 numbers were obtainable
+from the live dev session; the sweep is pending a detached/quiesced launch.** (See
+[h9-machine-contention-blocker] in agent memory.)
 
 The E1 reframe is accepted. The binding constraint for a daily local agent is **headroom the user isn't already using**, not total RAM. Answers to the three open questions, then the revised plan.
 

--- a/scripts/h9_e2_kv_workload.py
+++ b/scripts/h9_e2_kv_workload.py
@@ -141,26 +141,43 @@ def _make_transcript(sample_idx: int, min_chars: int) -> str:
     return "".join(parts)
 
 
+def _templated(tokenizer, transcript: str) -> tuple[str, int]:
+    msgs = [{"role": "user", "content": SUMMARIZE_INSTRUCTION + transcript}]
+    templated = tokenizer.apply_chat_template(
+        msgs, add_generation_prompt=True, tokenize=False
+    )
+    return templated, len(tokenizer.encode(templated))
+
+
 def build_transcript_prompt(tokenizer, target_tokens: int, sample_idx: int) -> tuple[str, int]:
-    """Build a chat-templated summarization prompt of ~exactly target_tokens, deterministically."""
-    # Reserve headroom for the chat template + instruction; grow transcript until total >= target.
-    chars = target_tokens * 3  # rough chars/token seed
-    while True:
-        transcript = _make_transcript(sample_idx, chars)
-        content = SUMMARIZE_INSTRUCTION + transcript
-        msgs = [{"role": "user", "content": content}]
-        templated = tokenizer.apply_chat_template(
-            msgs, add_generation_prompt=True, tokenize=False
-        )
-        toks = tokenizer.encode(templated)
-        if len(toks) >= target_tokens:
-            break
+    """Build a chat-templated summarization prompt of ~target_tokens, deterministically.
+
+    CRITICAL (code-review R2-P1): we trim the TRANSCRIPT BODY and re-apply the chat template
+    each time, so the assistant generation suffix (the "now answer" turn) is ALWAYS preserved
+    at the end. Slicing the already-templated token sequence would strip that suffix and the
+    model would just continue an unfinished user turn instead of summarizing — silently
+    invalidating both the generated summary and the PPL gate.
+    """
+    # Grow the transcript body until the FULL templated prompt reaches the target.
+    chars = target_tokens * 3
+    transcript = _make_transcript(sample_idx, chars)
+    _, ntok = _templated(tokenizer, transcript)
+    while ntok < target_tokens:
         chars = int(chars * 1.3) + 256
-    # Trim transcript body down to hit target exactly (slice tokens, re-decode).
-    toks = toks[:target_tokens]
-    text = tokenizer.decode(toks)
-    actual = len(tokenizer.encode(text))
-    return text, actual
+        transcript = _make_transcript(sample_idx, chars)
+        _, ntok = _templated(tokenizer, transcript)
+
+    # Binary-search the transcript length (in chars) so the templated total lands near target.
+    lo, hi = 0, len(transcript)
+    while lo < hi:
+        mid = (lo + hi + 1) // 2
+        _, n = _templated(tokenizer, transcript[:mid])
+        if n <= target_tokens:
+            lo = mid
+        else:
+            hi = mid - 1
+    templated, actual = _templated(tokenizer, transcript[:lo])
+    return templated, actual
 
 
 # ---------------------------------------------------------------------------
@@ -625,7 +642,14 @@ def _aggregate_and_log(L, dims, kv16, kv4, kv16_skipped, kv4_skipped, pf16, pf4,
     # per-GB is meaningless (pure analytic, nothing ran) when BOTH configs were skipped —
     # surface None so _final_verdict doesn't read a spurious pass (code-review R3).
     both_skipped = kv16_skipped and kv4_skipped
-    pergb_pass = None if both_skipped else (per_gb_ratio >= PERGB_GATE)
+    if both_skipped:
+        pergb_pass = None
+    elif memory_inconclusive:
+        # .nbytes vs analytic diverged > tolerance — the memory measurement is invalid, so the
+        # per-GB gate cannot PASS on it (code-review R2-P2).
+        pergb_pass = False
+    else:
+        pergb_pass = per_gb_ratio >= PERGB_GATE
     no_oom = not kv4_skipped
     kv16_oom_path = kv16_skipped and not kv4_skipped  # PASS-with-asterisk case
 

--- a/scripts/h9_e2_kv_workload.py
+++ b/scripts/h9_e2_kv_workload.py
@@ -1,0 +1,697 @@
+"""
+h9_e2_kv_workload.py — KV quantization at workload context lengths (issue #36, H9-E2 Arm a).
+
+Validates H7's kv4 result (`kv_bits=4, kv_group_size=64`, zero PPL loss) on the REAL Tier-1
+model (Qwen3-30B-A3B-4bit) at the REAL workload context lengths (10K/12K/15K-token
+call-transcript summarization), and quantifies effective-context-per-GB of KV cache.
+
+Scope (plan.md): in-process mlx_lm engine tier, idle 24 GB M4 Pro (off-hours tier). NOT the
+16 GB daily-driver budget; NOT the vllm-mlx served tier (follow-up). Arm (b) llama.cpp is
+deferred (blocked on E1b host contention).
+
+Method (see dev/active/issue-36-h9-e2-kv-quant/plan.md):
+  - Synthetic multi-speaker meeting transcripts, deterministically seeded by sample index,
+    tokenizer-trimmed to exactly 10240 / 12288 / 15360 tokens.
+  - Per (length, config in {kv16, kv4}):
+      * Two-stage memory preflight (pre-load total-budget + post-load incremental headroom),
+        no double-counting of weights. Skip + log if it won't fit.
+      * Prefill the transcript into a prompt_cache; apply maybe_quantize_kv_cache for kv4
+        (quantized_kv_start=0); ASSERT every entry is QuantizedKVCache for kv4.
+      * KV-cache size read DIRECTLY via sum(c.nbytes) (gate metric), cross-checked vs the
+        analytic formula (hard validity gate: must agree within 25%).
+      * Quality: pin the kv16 greedy summary as the target, teacher-force it through the
+        SAME cached path under both configs, score NLL on summary-token positions only
+        (summary-only ΔPPL is the formal gate). ROUGE-L is a divergence trigger, not a gate.
+      * Speed: prefill tok/s, decode tok/s, TTFT (reporting; >10% kv4 slowdown flagged).
+  - Gates: summary-only |ΔPPL| <= 1% rel + spot-check; effective ctx/GB >= 1.5x; no OOM @15K.
+
+Usage:
+  uv run python scripts/h9_e2_kv_workload.py smoke           # Phase A de-risk + compat gate
+  uv run python scripts/h9_e2_kv_workload.py run             # full sweep (all lengths)
+  uv run python scripts/h9_e2_kv_workload.py run --lengths 10240 --samples 2   # quick subset
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import math
+import statistics
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import psutil
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from h9_e1_baseline import tree_footprint_gb  # noqa: E402
+from experiment_utils import (  # noqa: E402
+    get_available_memory_gb,
+    get_environment_info,
+    log_experiment,
+)
+
+MODEL = "mlx-community/Qwen3-30B-A3B-4bit"
+LOGDIR = Path(__file__).parent.parent / "dev" / "active" / "issue-36-h9-e2-kv-quant" / "logs"
+SUMMARY_DIR = LOGDIR / "summaries"
+TRANSCRIPT_DIR = LOGDIR / "transcripts"
+
+# Pinned configuration (plan.md "Pinned configuration") — every value logged.
+LENGTHS = [10240, 12288, 15360]
+KV_GROUP_SIZE = 64
+QUANTIZED_KV_START = 0
+MAX_TOKENS = 256
+SAMPLES_PER_LENGTH = 5
+WEIGHTS_GB = 16.55          # E1-measured MLX-wired footprint of this model
+SCRATCH_GB = 2.0           # MLX/Metal prefill scratch margin at 15K
+SAFETY_GB = 1.0
+USABLE_CAP_GB = 20.0       # idle 24 GB host usable cap (conservative within 19-21 GB)
+NBYTES_ANALYTIC_TOL = 0.25 # hard validity gate: .nbytes vs analytic must agree within 25%
+PPL_GATE_REL = 0.01        # |ΔPPL| <= 1% relative
+PERGB_GATE = 1.5           # effective ctx/GB >= 1.5x
+ROUGE_REVIEW_FLOOR = 0.90  # below this, escalate spot-check (not a hard fail)
+SPEED_FLAG_REL = 0.10      # flag if kv4 >10% slower than kv16
+
+SUMMARIZE_INSTRUCTION = (
+    "You are an operations assistant. Read the following meeting transcript and write a "
+    "concise, well-structured summary covering the key decisions, owners, dates, open "
+    "questions, and next actions. Be specific and faithful to the transcript.\n\n"
+    "TRANSCRIPT:\n"
+)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic multi-speaker meeting transcripts (deterministic, seeded by index)
+# ---------------------------------------------------------------------------
+
+_SPEAKERS = ["Alex", "Priya", "Diego", "Sam", "Mei", "Jordan"]
+_TOPICS = [
+    ("quarterly planning", [
+        "we need to lock the Q3 roadmap before the board sync on the 14th",
+        "the infra migration is the long pole; it slips two weeks if hiring stalls",
+        "marketing wants the launch gated on the analytics dashboard being live",
+        "let's commit to three OKRs, not seven, and actually fund them",
+        "the budget delta from last quarter is about 12 percent, mostly cloud",
+    ]),
+    ("customer escalation", [
+        "the Acme account is threatening to churn over the latency regression",
+        "we traced it to the new routing layer under burst load past 5K rps",
+        "support promised a fix by Friday; eng thinks Tuesday is realistic",
+        "we should offer a credit and a roadmap review call, not just an apology",
+        "the renewal is 400K and the exec sponsor changed last month",
+    ]),
+    ("engineering standup", [
+        "the cache-coherency bug only reproduces under co-resident memory pressure",
+        "I rewrote the prefetch path; p50 dropped from 40ms to 0.4ms",
+        "the page cache hit rate is sitting around 70 percent under the Zipf workload",
+        "we still OOM on full Metal offload; partial offload with a trimmed prompt cache works",
+        "the quant pass for the experts is done; router stays at 4-bit for safety",
+    ]),
+    ("sales pipeline review", [
+        "pipeline coverage is 3.2x for the quarter but weighted is only 1.4x",
+        "two deals slipped to next quarter on procurement, not on product",
+        "the mid-market segment is closing 40 percent faster since the new demo flow",
+        "we need two more SDRs to feed the enterprise team or the funnel dries up",
+        "the competitor undercut us on the Globex deal; we won on the security review",
+    ]),
+    ("hiring debrief", [
+        "the staff candidate was strong on systems but light on the Metal specifics",
+        "we should make the offer but pair them with someone who knows the GPU path",
+        "the panel was split on the design round; the take-home was excellent",
+        "comp expectation is at the top of band; we can close the gap with equity",
+        "let's move the second candidate to onsite and keep this one warm",
+    ]),
+]
+
+
+def _make_transcript(sample_idx: int, min_chars: int) -> str:
+    """Deterministic synthetic meeting transcript; varied by sample_idx (no RNG / no clock)."""
+    topic_name, lines = _TOPICS[sample_idx % len(_TOPICS)]
+    parts = [f"[Meeting: {topic_name} — session {sample_idx}]\n"]
+    turn = sample_idx  # deterministic, index-varied
+    while sum(len(p) for p in parts) < min_chars:
+        spk = _SPEAKERS[turn % len(_SPEAKERS)]
+        line = lines[turn % len(lines)]
+        # Vary phrasing deterministically so repetition isn't a single pathological token run.
+        filler = f" (point {turn}, ref {sample_idx}-{turn % 7})"
+        parts.append(f"{spk}: {line}{filler}.\n")
+        turn += 1
+    return "".join(parts)
+
+
+def build_transcript_prompt(tokenizer, target_tokens: int, sample_idx: int) -> tuple[str, int]:
+    """Build a chat-templated summarization prompt of ~exactly target_tokens, deterministically."""
+    # Reserve headroom for the chat template + instruction; grow transcript until total >= target.
+    chars = target_tokens * 3  # rough chars/token seed
+    while True:
+        transcript = _make_transcript(sample_idx, chars)
+        content = SUMMARIZE_INSTRUCTION + transcript
+        msgs = [{"role": "user", "content": content}]
+        templated = tokenizer.apply_chat_template(
+            msgs, add_generation_prompt=True, tokenize=False
+        )
+        toks = tokenizer.encode(templated)
+        if len(toks) >= target_tokens:
+            break
+        chars = int(chars * 1.3) + 256
+    # Trim transcript body down to hit target exactly (slice tokens, re-decode).
+    toks = toks[:target_tokens]
+    text = tokenizer.decode(toks)
+    actual = len(tokenizer.encode(text))
+    return text, actual
+
+
+# ---------------------------------------------------------------------------
+# Analytic + direct KV-cache sizing
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ModelDims:
+    n_layers: int
+    n_kv_heads: int
+    head_dim: int
+
+
+def _model_dims(model) -> ModelDims:
+    cfg = getattr(model, "args", None) or getattr(model, "config", None)
+    # Qwen3 MoE config field names; fall back through common aliases.
+    def g(*names, default=None):
+        for n in names:
+            v = getattr(cfg, n, None)
+            if v is not None:
+                return v
+        return default
+
+    n_layers = g("num_hidden_layers", "n_layers")
+    n_kv = g("num_key_value_heads", "n_kv_heads", default=g("num_attention_heads", "n_heads"))
+    hidden = g("hidden_size", "d_model")
+    n_heads = g("num_attention_heads", "n_heads")
+    head_dim = g("head_dim", default=(hidden // n_heads if hidden and n_heads else None))
+    return ModelDims(int(n_layers), int(n_kv), int(head_dim))
+
+
+def analytic_kv_bytes(dims: ModelDims, seq_len: int, kv_bits: Optional[int]) -> float:
+    """Analytic KV-cache bytes. kv16 = fp16 K+V; kv4 = 4-bit + per-group fp16 scale+bias."""
+    elems = 2 * dims.n_layers * dims.n_kv_heads * dims.head_dim * seq_len  # K + V elements
+    if kv_bits is None:  # fp16
+        return elems * 2
+    # quantized: kv_bits per element + (scale+bias) fp16 per group of KV_GROUP_SIZE
+    per_elem = kv_bits / 8.0
+    groups = elems / KV_GROUP_SIZE
+    return elems * per_elem + groups * 2 * 2  # 2 (scale,bias) * 2 bytes(fp16)
+
+
+def direct_kv_bytes(prompt_cache) -> int:
+    """Exact KV-cache bytes via each cache entry's .nbytes (KVCache or QuantizedKVCache)."""
+    total = 0
+    for c in prompt_cache:
+        nb = getattr(c, "nbytes", None)
+        if nb is not None:
+            total += int(nb)
+    return total
+
+
+# ---------------------------------------------------------------------------
+# Generation + teacher-forced scoring through the cached (possibly quantized) path
+# ---------------------------------------------------------------------------
+
+
+def _prefill_and_quantize(model, prompt_ids, kv_bits: Optional[int]):
+    """Prefill prompt into a fresh prompt_cache; quantize it for kv4. Returns the cache."""
+    import mlx.core as mx
+    from mlx_lm.models.cache import make_prompt_cache
+    from mlx_lm.generate import maybe_quantize_kv_cache
+
+    cache = make_prompt_cache(model)
+    x = mx.array(prompt_ids)[None]
+    logits = model(x, cache=cache)
+    mx.eval(logits)
+    # Quantize after prefill (offset now == prompt_len >= quantized_kv_start=0).
+    maybe_quantize_kv_cache(cache, QUANTIZED_KV_START, KV_GROUP_SIZE, kv_bits)
+    mx.eval([c.state for c in cache])
+    last_logits = logits[:, -1, :]
+    return cache, last_logits
+
+
+def _assert_quantized(cache):
+    from mlx_lm.models.cache import QuantizedKVCache
+
+    bad = [i for i, c in enumerate(cache) if not isinstance(c, QuantizedKVCache)]
+    return len(bad) == 0, bad
+
+
+def greedy_generate(model, prompt_ids, kv_bits: Optional[int], max_tokens: int):
+    """Greedy decode through the cached path. Returns (gen_ids, timing, cache)."""
+    import time
+
+    import mlx.core as mx
+
+    t0 = time.perf_counter()
+    cache, last_logits = _prefill_and_quantize(model, prompt_ids, kv_bits)
+    tok = mx.argmax(last_logits, axis=-1)
+    mx.eval(tok)
+    ttft = time.perf_counter() - t0
+    prefill_tps = len(prompt_ids) / ttft if ttft > 0 else 0.0
+
+    gen = [int(tok.item())]
+    t_dec = time.perf_counter()
+    for _ in range(max_tokens - 1):
+        logits = model(tok[None], cache=cache)
+        tok = mx.argmax(logits[:, -1, :], axis=-1)
+        mx.eval(tok)
+        gen.append(int(tok.item()))
+    dec_elapsed = time.perf_counter() - t_dec
+    decode_tps = (len(gen) - 1) / dec_elapsed if dec_elapsed > 0 else 0.0
+    timing = {
+        "ttft_s": round(ttft, 3),
+        "prefill_tok_s": round(prefill_tps, 1),
+        "decode_tok_s": round(decode_tps, 1),
+    }
+    return gen, timing, cache
+
+
+def teacher_forced_nll(model, prompt_ids, target_ids, kv_bits: Optional[int]):
+    """Score NLL on target_ids ONLY, conditioned on prompt via the (possibly quantized) cache.
+
+    Returns (sum_nll, n_tokens, quantized_ok, bad_layers). Routes through the same incremental
+    cached path generation uses, so the quantized K/V actually participate (plan-review R5-R2).
+    """
+    import mlx.core as mx
+    import mlx.nn as nn
+
+    cache, last_logits = _prefill_and_quantize(model, prompt_ids, kv_bits)
+    quantized_ok, bad = (True, [])
+    if kv_bits is not None:
+        quantized_ok, bad = _assert_quantized(cache)
+
+    # last_logits predicts the FIRST target token; then feed each target token to get the next.
+    total_nll = 0.0
+    logits = last_logits  # predicts target_ids[0]
+    for i, tgt in enumerate(target_ids):
+        logp = nn.log_softmax(logits, axis=-1)
+        total_nll += -float(logp[0, tgt].item())
+        if i < len(target_ids) - 1:
+            tok = mx.array([tgt])
+            out = model(tok[None], cache=cache)
+            logits = out[:, -1, :]
+            mx.eval(logits)
+    return total_nll, len(target_ids), quantized_ok, bad
+
+
+def rouge_l(ref_ids, hyp_ids) -> float:
+    """ROUGE-L (LCS-based F1) over token id sequences. Divergence trigger, not a gate."""
+    if not ref_ids or not hyp_ids:
+        return 0.0
+    n, m = len(ref_ids), len(hyp_ids)
+    # LCS length via DP (token sequences are <=256, cheap).
+    dp = [0] * (m + 1)
+    for i in range(1, n + 1):
+        prev = 0
+        for j in range(1, m + 1):
+            tmp = dp[j]
+            dp[j] = prev + 1 if ref_ids[i - 1] == hyp_ids[j - 1] else max(dp[j], dp[j - 1])
+            prev = tmp
+    lcs = dp[m]
+    if lcs == 0:
+        return 0.0
+    prec, rec = lcs / m, lcs / n
+    return 2 * prec * rec / (prec + rec)
+
+
+# ---------------------------------------------------------------------------
+# Memory preflight (two-stage, no double-count — plan-review R5-R1)
+# ---------------------------------------------------------------------------
+
+
+def preflight(dims: ModelDims, seq_len: int, kv_bits: Optional[int], model_loaded: bool) -> dict:
+    kv_gb = analytic_kv_bytes(dims, seq_len + MAX_TOKENS, kv_bits) / (1024**3)
+    incremental = kv_gb + SCRATCH_GB + SAFETY_GB
+    total = WEIGHTS_GB + incremental
+    avail = get_available_memory_gb()
+    if not model_loaded:
+        ok = total <= USABLE_CAP_GB
+        return {"stage": "pre_load", "analytic_kv_gb": round(kv_gb, 3),
+                "total_required_gb": round(total, 2), "usable_cap_gb": USABLE_CAP_GB,
+                "available_gb": round(avail, 2), "ok": ok}
+    ok = incremental <= avail
+    return {"stage": "post_load", "analytic_kv_gb": round(kv_gb, 3),
+            "incremental_required_gb": round(incremental, 2),
+            "available_gb": round(avail, 2), "ok": ok}
+
+
+# ---------------------------------------------------------------------------
+# Phase A — smoke / compatibility gate
+# ---------------------------------------------------------------------------
+
+
+def cmd_smoke(args):
+    import mlx.core as mx
+    from mlx_lm import load
+
+    LOGDIR.mkdir(parents=True, exist_ok=True)
+    avail = get_available_memory_gb()
+    print(f"[smoke] available memory: {avail:.2f} GB")
+    if avail < WEIGHTS_GB + 1.5:
+        print(f"[smoke] ABORT: < {WEIGHTS_GB + 1.5:.1f} GB free — quiesce the machine "
+              f"(quit Cursor/Chrome/extra Claude procs) per the machine-contention blocker.")
+        log_experiment(
+            "h9_e2_smoke", "h9_e2_kv_workload",
+            {"model": MODEL}, {"status": "aborted_low_memory", "available_gb": round(avail, 2)},
+            status="aborted",
+        )
+        return 1
+
+    print(f"[smoke] loading {MODEL} ...")
+    model, tokenizer = load(MODEL)
+    dims = _model_dims(model)
+    print(f"[smoke] dims: n_layers={dims.n_layers} n_kv_heads={dims.n_kv_heads} "
+          f"head_dim={dims.head_dim}")
+    loaded_gb, _ = tree_footprint_gb(psutil.Process().pid)
+    print(f"[smoke] loaded footprint: {loaded_gb:.2f} GB")
+
+    # kv4 compatibility gate: short + medium prompt, confirm slope differs (plan-review R3-medium).
+    results = {}
+    for label, ntok in [("short", 256), ("medium", 2048)]:
+        prompt, actual = build_transcript_prompt(tokenizer, ntok, 0)
+        pid = tokenizer.encode(prompt)
+        for kvb, key in [(None, "kv16"), (4, "kv4")]:
+            cache, _ = _prefill_and_quantize(model, pid, kvb)
+            direct = direct_kv_bytes(cache)
+            ana = analytic_kv_bytes(dims, actual, kvb)
+            qok, bad = (True, []) if kvb is None else _assert_quantized(cache)
+            results[f"{label}_{key}"] = {
+                "seq": actual, "direct_kv_mb": round(direct / 1e6, 2),
+                "analytic_kv_mb": round(ana / 1e6, 2),
+                "quantized_ok": qok, "bad_layers": bad,
+            }
+            print(f"  {label}/{key}: seq={actual} direct={direct/1e6:.1f}MB "
+                  f"analytic={ana/1e6:.1f}MB quantized_ok={qok}")
+            del cache
+            gc.collect()
+            mx.clear_cache()
+
+    # Slope check: kv4 cache must grow ~3.5x slower than kv16 between short and medium.
+    d16 = results["medium_kv16"]["direct_kv_mb"] - results["short_kv16"]["direct_kv_mb"]
+    d4 = results["medium_kv4"]["direct_kv_mb"] - results["short_kv4"]["direct_kv_mb"]
+    slope_ratio = (d16 / d4) if d4 > 0 else float("inf")
+    compat_ok = results["medium_kv4"]["quantized_ok"] and slope_ratio >= 2.5
+    print(f"[smoke] kv16 slope={d16:.1f}MB kv4 slope={d4:.1f}MB ratio={slope_ratio:.2f} "
+          f"=> compat_ok={compat_ok}")
+
+    status = "completed" if compat_ok else "infra_fail_kv_quant_unsupported"
+    log_experiment(
+        "h9_e2_smoke", "h9_e2_kv_workload",
+        {"model": MODEL, "kv_group_size": KV_GROUP_SIZE,
+         "quantized_kv_start": QUANTIZED_KV_START,
+         "n_layers": dims.n_layers, "n_kv_heads": dims.n_kv_heads, "head_dim": dims.head_dim},
+        {"loaded_footprint_gb": round(loaded_gb, 2), "slope_ratio_kv16_over_kv4": round(slope_ratio, 2),
+         "compat_ok": compat_ok, "cells": results,
+         "cache_hit_rate": None,
+         "cache_hit_rate_reason": "not applicable: no expert/page cache in MLX KV quant arm",
+         "gpu_memory_mb": round(mx.get_peak_memory() / 1e6, 1)},
+        status=status,
+    )
+    if not compat_ok:
+        print("[smoke] INFRA FAIL: kv4 path did not change the memory slope as expected.")
+        return 1
+    print("[smoke] PASS — kv4 quantization is engaged and the measurement path works.")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Phase B/C — the sweep
+# ---------------------------------------------------------------------------
+
+
+def _summarize_once(model, tokenizer, prompt_ids, kv_bits):
+    """Generate a greedy summary; return (gen_ids, summary_text, timing, kv_direct, kv_analytic, qok)."""
+    import mlx.core as mx
+
+    dims = _model_dims(model)
+    mx.reset_peak_memory()
+    base_active = mx.get_active_memory()
+    gen, timing, cache = greedy_generate(model, prompt_ids, kv_bits, MAX_TOKENS)
+    mx.eval([c.state for c in cache])
+    cache_active = mx.get_active_memory()
+    direct = direct_kv_bytes(cache)
+    analytic = analytic_kv_bytes(dims, len(prompt_ids) + len(gen), kv_bits)
+    qok, _ = (True, []) if kv_bits is None else _assert_quantized(cache)
+    steady_delta = max(0, cache_active - base_active)
+    text = tokenizer.decode(gen)
+    del cache
+    gc.collect()
+    mx.clear_cache()
+    return {
+        "gen_ids": gen, "summary": text, "timing": timing,
+        "kv_direct_bytes": direct, "kv_analytic_bytes": analytic,
+        "kv_steady_delta_bytes": steady_delta, "quantized_ok": qok,
+        "peak_gpu_mb": round(mx.get_peak_memory() / 1e6, 1),
+    }
+
+
+def cmd_run(args):
+    from mlx_lm import load
+
+    LOGDIR.mkdir(parents=True, exist_ok=True)
+    SUMMARY_DIR.mkdir(parents=True, exist_ok=True)
+    TRANSCRIPT_DIR.mkdir(parents=True, exist_ok=True)
+    env = get_environment_info()
+
+    lengths = args.lengths or LENGTHS
+    n_samples = args.samples or SAMPLES_PER_LENGTH
+
+    avail = get_available_memory_gb()
+    print(f"[run] available memory: {avail:.2f} GB")
+    if avail < WEIGHTS_GB + 1.5:
+        print(f"[run] ABORT: quiesce the machine first (need > {WEIGHTS_GB + 1.5:.1f} GB free).")
+        return 1
+
+    print(f"[run] loading {MODEL} ...")
+    model, tokenizer = load(MODEL)
+    dims = _model_dims(model)
+    print(f"[run] dims: {dims}")
+
+    per_length_verdicts = {}
+
+    for L in lengths:
+        print(f"\n========== context length {L} ==========")
+        # Pre-load budget is informational here (model already loaded); run post-load check.
+        pf16 = preflight(dims, L, None, model_loaded=True)
+        pf4 = preflight(dims, L, 4, model_loaded=True)
+        print(f"[preflight L={L}] kv16 {pf16}  | kv4 {pf4}")
+
+        samples_kv16, samples_kv4 = [], []
+        kv16_skipped = not pf16["ok"]
+        kv4_skipped = not pf4["ok"]
+
+        for s in range(n_samples):
+            prompt, actual = build_transcript_prompt(tokenizer, L, s)
+            (TRANSCRIPT_DIR / f"L{L}_s{s}.txt").write_text(prompt)
+            prompt_ids = tokenizer.encode(prompt)
+            print(f"  [L={L} s={s}] prompt tokens={actual}")
+
+            # kv16 first — its summary is the pinned scoring + ROUGE target.
+            r16 = None
+            if not kv16_skipped:
+                try:
+                    r16 = _summarize_once(model, tokenizer, prompt_ids, None)
+                except Exception as e:  # OOM or runtime
+                    print(f"    kv16 FAILED at L={L}: {e}")
+                    kv16_skipped = True
+            r4 = None
+            if not kv4_skipped:
+                try:
+                    r4 = _summarize_once(model, tokenizer, prompt_ids, 4)
+                except Exception as e:
+                    print(f"    kv4 FAILED at L={L}: {e}")
+                    kv4_skipped = True
+
+            # Quality: teacher-force the kv16 summary under both configs (summary-only ΔPPL).
+            ppl16 = ppl4 = None
+            quantized_ok = None
+            rouge = None
+            if r16 is not None:
+                target = r16["gen_ids"]
+                nll16, n16, _, _ = teacher_forced_nll(model, prompt_ids, target, None)
+                ppl16 = math.exp(nll16 / n16)
+                if r4 is not None:
+                    nll4, n4, quantized_ok, bad = teacher_forced_nll(model, prompt_ids, target, 4)
+                    ppl4 = math.exp(nll4 / n4)
+                    rouge = rouge_l(r16["gen_ids"], r4["gen_ids"])
+                    (SUMMARY_DIR / f"L{L}_s{s}_kv16.txt").write_text(r16["summary"])
+                    (SUMMARY_DIR / f"L{L}_s{s}_kv4.txt").write_text(r4["summary"])
+
+            if r16 is not None:
+                samples_kv16.append({"seq": actual, "ppl": ppl16, **r16["timing"],
+                                     "kv_direct_bytes": r16["kv_direct_bytes"],
+                                     "kv_analytic_bytes": r16["kv_analytic_bytes"],
+                                     "peak_gpu_mb": r16["peak_gpu_mb"]})
+            if r4 is not None:
+                samples_kv4.append({"seq": actual, "ppl": ppl4, **r4["timing"],
+                                    "kv_direct_bytes": r4["kv_direct_bytes"],
+                                    "kv_analytic_bytes": r4["kv_analytic_bytes"],
+                                    "peak_gpu_mb": r4["peak_gpu_mb"],
+                                    "quantized_ok": quantized_ok, "rouge_l_vs_kv16": rouge})
+            if ppl16 is not None and ppl4 is not None:
+                d = abs(ppl4 - ppl16) / ppl16
+                print(f"    ppl16={ppl16:.4f} ppl4={ppl4:.4f} Δrel={d:.4%} "
+                      f"rougeL={rouge:.3f} quantized_ok={quantized_ok}")
+
+        verdict = _aggregate_and_log(L, dims, samples_kv16, samples_kv4,
+                                     kv16_skipped, kv4_skipped, pf16, pf4, env)
+        per_length_verdicts[L] = verdict
+
+    _final_verdict(per_length_verdicts, env)
+    return 0
+
+
+def _median(xs):
+    xs = [x for x in xs if x is not None]
+    return statistics.median(xs) if xs else None
+
+
+def _aggregate_and_log(L, dims, kv16, kv4, kv16_skipped, kv4_skipped, pf16, pf4, env) -> dict:
+    seq_full = L + MAX_TOKENS
+
+    def kv_gb(samples, kvb):
+        if samples:
+            return _median([s["kv_direct_bytes"] for s in samples]) / (1024**3)
+        return analytic_kv_bytes(dims, seq_full, kvb) / (1024**3)
+
+    kv16_gb = kv_gb(kv16, None)
+    kv4_gb = kv_gb(kv4, 4)
+
+    # .nbytes vs analytic hard validity gate (per config, when measured).
+    def validity(samples, kvb):
+        if not samples:
+            return {"measured": False}
+        direct = _median([s["kv_direct_bytes"] for s in samples])
+        ana = analytic_kv_bytes(dims, seq_full, kvb)
+        diverge = abs(direct - ana) / ana
+        return {"measured": True, "direct_bytes": int(direct), "analytic_bytes": int(ana),
+                "divergence": round(diverge, 4), "valid": diverge <= NBYTES_ANALYTIC_TOL}
+    v16, v4 = validity(kv16, None), validity(kv4, 4)
+    memory_inconclusive = (v16.get("measured") and not v16["valid"]) or \
+                          (v4.get("measured") and not v4["valid"])
+
+    per_gb_16 = seq_full / kv16_gb
+    per_gb_4 = seq_full / kv4_gb
+    per_gb_ratio = per_gb_4 / per_gb_16
+
+    # Quality gate: summary-only ΔPPL on paired samples.
+    deltas = []
+    for a, b in zip(kv16, kv4):
+        if a["ppl"] and b["ppl"]:
+            deltas.append(abs(b["ppl"] - a["ppl"]) / a["ppl"])
+    mean_dppl = statistics.mean(deltas) if deltas else None
+    rouges = [s.get("rouge_l_vs_kv16") for s in kv4 if s.get("rouge_l_vs_kv16") is not None]
+    mean_rouge = statistics.mean(rouges) if rouges else None
+
+    # Speed flag.
+    dec16, dec4 = _median([s["decode_tok_s"] for s in kv16]), _median([s["decode_tok_s"] for s in kv4])
+    pre16, pre4 = _median([s["prefill_tok_s"] for s in kv16]), _median([s["prefill_tok_s"] for s in kv4])
+    speed_flag = bool(dec16 and dec4 and dec4 < dec16 * (1 - SPEED_FLAG_REL))
+
+    # Gate evaluation (plan.md verdict classes).
+    quality_pass = (mean_dppl is not None and mean_dppl <= PPL_GATE_REL)
+    quality_status = "pass" if quality_pass else ("unverified" if kv16_skipped else "fail")
+    pergb_pass = per_gb_ratio >= PERGB_GATE
+    no_oom = not kv4_skipped
+    kv16_oom_path = kv16_skipped and not kv4_skipped  # PASS-with-asterisk case
+
+    verdict = {
+        "length": L,
+        "quality_status": quality_status,
+        "mean_dppl_rel": round(mean_dppl, 5) if mean_dppl is not None else None,
+        "mean_rouge_l": round(mean_rouge, 4) if mean_rouge is not None else None,
+        "rouge_below_review_floor": bool(mean_rouge is not None and mean_rouge < ROUGE_REVIEW_FLOOR),
+        "per_gb_ratio": round(per_gb_ratio, 3),
+        "per_gb_pass": pergb_pass,
+        "kv16_gb": round(kv16_gb, 4), "kv4_gb": round(kv4_gb, 4),
+        "no_oom_at_length": no_oom,
+        "kv16_oom_kv4_ok": kv16_oom_path,
+        "memory_inconclusive": memory_inconclusive,
+        "speed_flag_kv4_slower": speed_flag,
+    }
+
+    config = {
+        "model": MODEL, "runtime": "mlx_lm", "tier": "engine_offhours",
+        "context_length": L, "kv_group_size": KV_GROUP_SIZE,
+        "quantized_kv_start": QUANTIZED_KV_START, "max_tokens": MAX_TOKENS,
+        "n_samples": len(kv16) or len(kv4),
+        "n_layers": dims.n_layers, "n_kv_heads": dims.n_kv_heads, "head_dim": dims.head_dim,
+        "preflight_kv16": pf16, "preflight_kv4": pf4,
+    }
+    results = {
+        "mem_method": "phys_footprint+nbytes",
+        "verdict": verdict,
+        "kv16_samples": kv16, "kv4_samples": kv4,
+        "kv16_validity": v16, "kv4_validity": v4,
+        "median_decode_tok_s": {"kv16": dec16, "kv4": dec4},
+        "median_prefill_tok_s": {"kv16": pre16, "kv4": pre4},
+        "gpu_memory_mb": _median([s["peak_gpu_mb"] for s in (kv4 or kv16)]),
+        "cache_hit_rate": None,
+        "cache_hit_rate_reason": "not applicable: no expert/page cache in MLX KV quant arm",
+        "perplexity": {"kv16_mean": _median([s["ppl"] for s in kv16]),
+                       "kv4_mean": _median([s["ppl"] for s in kv4])},
+        "kv16_skipped": kv16_skipped, "kv4_skipped": kv4_skipped,
+    }
+    status = "completed"
+    if kv4_skipped and kv16_skipped:
+        status = "skipped_oom_preflight"
+    log_experiment(f"h9_e2_kv_workload_L{L}", "h9_e2_kv_workload", config, results,
+                   status=status, env=env)
+    print(f"[verdict L={L}] {verdict}")
+    return verdict
+
+
+def _final_verdict(per_length, env):
+    lengths = sorted(per_length)
+    quals = {L: per_length[L]["quality_status"] for L in lengths}
+    pergbs = {L: per_length[L]["per_gb_pass"] for L in lengths}
+    all_quality = all(q == "pass" for q in quals.values())
+    all_pergb = all(pergbs.values())
+    any_unverified = any(q == "unverified" for q in quals.values())
+
+    if all_quality and all_pergb:
+        overall = "PASS"
+    elif all_pergb and any_unverified and not any(q == "fail" for q in quals.values()):
+        overall = "PASS_WITH_ASTERISK"  # e.g. 15K kv16 OOM, quality proven through 12K
+    elif quals.get(lengths[0]) == "pass" and quals.get(lengths[1] if len(lengths) > 1 else lengths[0]) == "pass":
+        overall = "PARTIAL"
+    else:
+        overall = "FAIL"
+
+    summary = {
+        "overall_verdict": overall,
+        "scope": "24GB off-hours MLX engine tier; NOT the 16GB daily-driver budget; "
+                 "NOT vllm-mlx served (follow-up). Arm (b) llama.cpp deferred (E1b host blocker).",
+        "per_length": per_length,
+        "quality_by_length": quals,
+        "per_gb_pass_by_length": pergbs,
+    }
+    log_experiment("h9_e2_kv_workload_SUMMARY", "h9_e2_kv_workload",
+                   {"model": MODEL, "lengths": lengths}, summary,
+                   status="completed", env=env)
+    print(f"\n========== OVERALL VERDICT: {overall} ==========")
+    print(summary)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="H9-E2 KV quantization at workload context lengths")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("smoke")
+    r = sub.add_parser("run")
+    r.add_argument("--lengths", type=int, nargs="*", default=None)
+    r.add_argument("--samples", type=int, default=None)
+    args = ap.parse_args()
+    if args.cmd == "smoke":
+        return cmd_smoke(args)
+    return cmd_run(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/h9_e2_kv_workload.py
+++ b/scripts/h9_e2_kv_workload.py
@@ -219,20 +219,34 @@ def direct_kv_bytes(prompt_cache) -> int:
 # ---------------------------------------------------------------------------
 
 
+# Match mlx_lm.generate_step's default chunked prefill so quantization is interleaved between
+# chunks exactly as the production path does (code-review R1): a single 15K-token forward pass
+# would (a) apply quantization only once at the very end, and (b) allocate far larger prefill
+# scratch than the chunked path the daily workload actually uses.
+PREFILL_STEP_SIZE = 512
+
+
 def _prefill_and_quantize(model, prompt_ids, kv_bits: Optional[int]):
-    """Prefill prompt into a fresh prompt_cache; quantize it for kv4. Returns the cache."""
+    """Prefill prompt into a fresh prompt_cache using chunked prefill (mlx_lm semantics);
+    quantize the cache progressively between chunks for kv4. Returns (cache, last_logits)."""
     import mlx.core as mx
     from mlx_lm.models.cache import make_prompt_cache
     from mlx_lm.generate import maybe_quantize_kv_cache
 
     cache = make_prompt_cache(model)
-    x = mx.array(prompt_ids)[None]
-    logits = model(x, cache=cache)
-    mx.eval(logits)
-    # Quantize after prefill (offset now == prompt_len >= quantized_kv_start=0).
-    maybe_quantize_kv_cache(cache, QUANTIZED_KV_START, KV_GROUP_SIZE, kv_bits)
-    mx.eval([c.state for c in cache])
-    last_logits = logits[:, -1, :]
+    ids = mx.array(prompt_ids)
+    n = ids.shape[0]
+    last_logits = None
+    i = 0
+    while i < n:
+        chunk = ids[i:i + PREFILL_STEP_SIZE][None]
+        logits = model(chunk, cache=cache)
+        # Interleave quantization between chunks (offset grows past quantized_kv_start=0).
+        maybe_quantize_kv_cache(cache, QUANTIZED_KV_START, KV_GROUP_SIZE, kv_bits)
+        mx.eval([c.state for c in cache])
+        i += PREFILL_STEP_SIZE
+        last_logits = logits[:, -1, :]
+    mx.eval(last_logits)
     return cache, last_logits
 
 
@@ -525,12 +539,12 @@ def cmd_run(args):
                     (SUMMARY_DIR / f"L{L}_s{s}_kv4.txt").write_text(r4["summary"])
 
             if r16 is not None:
-                samples_kv16.append({"seq": actual, "ppl": ppl16, **r16["timing"],
+                samples_kv16.append({"sample_idx": s, "seq": actual, "ppl": ppl16, **r16["timing"],
                                      "kv_direct_bytes": r16["kv_direct_bytes"],
                                      "kv_analytic_bytes": r16["kv_analytic_bytes"],
                                      "peak_gpu_mb": r16["peak_gpu_mb"]})
             if r4 is not None:
-                samples_kv4.append({"seq": actual, "ppl": ppl4, **r4["timing"],
+                samples_kv4.append({"sample_idx": s, "seq": actual, "ppl": ppl4, **r4["timing"],
                                     "kv_direct_bytes": r4["kv_direct_bytes"],
                                     "kv_analytic_bytes": r4["kv_analytic_bytes"],
                                     "peak_gpu_mb": r4["peak_gpu_mb"],
@@ -554,37 +568,47 @@ def _median(xs):
 
 
 def _aggregate_and_log(L, dims, kv16, kv4, kv16_skipped, kv4_skipped, pf16, pf4, env) -> dict:
-    seq_full = L + MAX_TOKENS
+    # Use the REALIZED median seq length (code-review R5): tokenizer round-trip can make the
+    # actual prompt differ from L by a few tokens, and the cache also holds MAX_TOKENS decoded.
+    def realized_seq(samples):
+        s = _median([x["seq"] for x in samples])
+        return int(s) + MAX_TOKENS if s is not None else (L + MAX_TOKENS)
+    seq16, seq4 = realized_seq(kv16), realized_seq(kv4)
 
-    def kv_gb(samples, kvb):
+    def kv_gb(samples, kvb, seq):
         if samples:
             return _median([s["kv_direct_bytes"] for s in samples]) / (1024**3)
-        return analytic_kv_bytes(dims, seq_full, kvb) / (1024**3)
+        return analytic_kv_bytes(dims, seq, kvb) / (1024**3)
 
-    kv16_gb = kv_gb(kv16, None)
-    kv4_gb = kv_gb(kv4, 4)
+    kv16_gb = kv_gb(kv16, None, seq16)
+    kv4_gb = kv_gb(kv4, 4, seq4)
 
-    # .nbytes vs analytic hard validity gate (per config, when measured).
-    def validity(samples, kvb):
+    # .nbytes vs analytic hard validity gate (per config, when measured) — analytic at the
+    # realized seq so the comparison is apples-to-apples.
+    def validity(samples, kvb, seq):
         if not samples:
             return {"measured": False}
         direct = _median([s["kv_direct_bytes"] for s in samples])
-        ana = analytic_kv_bytes(dims, seq_full, kvb)
+        ana = analytic_kv_bytes(dims, seq, kvb)
         diverge = abs(direct - ana) / ana
         return {"measured": True, "direct_bytes": int(direct), "analytic_bytes": int(ana),
                 "divergence": round(diverge, 4), "valid": diverge <= NBYTES_ANALYTIC_TOL}
-    v16, v4 = validity(kv16, None), validity(kv4, 4)
+    v16, v4 = validity(kv16, None, seq16), validity(kv4, 4, seq4)
     memory_inconclusive = (v16.get("measured") and not v16["valid"]) or \
                           (v4.get("measured") and not v4["valid"])
 
-    per_gb_16 = seq_full / kv16_gb
-    per_gb_4 = seq_full / kv4_gb
+    # per-GB ratio uses each config's own realized seq (they're near-identical by construction).
+    per_gb_16 = seq16 / kv16_gb
+    per_gb_4 = seq4 / kv4_gb
     per_gb_ratio = per_gb_4 / per_gb_16
 
-    # Quality gate: summary-only ΔPPL on paired samples.
+    # Quality gate: summary-only ΔPPL on samples PAIRED BY sample_idx (code-review R4 — a
+    # mid-sweep failure in one config must not silently mis-pair the positional lists).
+    kv4_by_idx = {s["sample_idx"]: s for s in kv4}
     deltas = []
-    for a, b in zip(kv16, kv4):
-        if a["ppl"] and b["ppl"]:
+    for a in kv16:
+        b = kv4_by_idx.get(a["sample_idx"])
+        if b and a["ppl"] and b["ppl"]:
             deltas.append(abs(b["ppl"] - a["ppl"]) / a["ppl"])
     mean_dppl = statistics.mean(deltas) if deltas else None
     rouges = [s.get("rouge_l_vs_kv16") for s in kv4 if s.get("rouge_l_vs_kv16") is not None]
@@ -598,7 +622,10 @@ def _aggregate_and_log(L, dims, kv16, kv4, kv16_skipped, kv4_skipped, pf16, pf4,
     # Gate evaluation (plan.md verdict classes).
     quality_pass = (mean_dppl is not None and mean_dppl <= PPL_GATE_REL)
     quality_status = "pass" if quality_pass else ("unverified" if kv16_skipped else "fail")
-    pergb_pass = per_gb_ratio >= PERGB_GATE
+    # per-GB is meaningless (pure analytic, nothing ran) when BOTH configs were skipped —
+    # surface None so _final_verdict doesn't read a spurious pass (code-review R3).
+    both_skipped = kv16_skipped and kv4_skipped
+    pergb_pass = None if both_skipped else (per_gb_ratio >= PERGB_GATE)
     no_oom = not kv4_skipped
     kv16_oom_path = kv16_skipped and not kv4_skipped  # PASS-with-asterisk case
 
@@ -621,7 +648,7 @@ def _aggregate_and_log(L, dims, kv16, kv4, kv16_skipped, kv4_skipped, pf16, pf4,
         "model": MODEL, "runtime": "mlx_lm", "tier": "engine_offhours",
         "context_length": L, "kv_group_size": KV_GROUP_SIZE,
         "quantized_kv_start": QUANTIZED_KV_START, "max_tokens": MAX_TOKENS,
-        "n_samples": len(kv16) or len(kv4),
+        "n_kv16_samples": len(kv16), "n_kv4_samples": len(kv4),
         "n_layers": dims.n_layers, "n_kv_heads": dims.n_kv_heads, "head_dim": dims.head_dim,
         "preflight_kv16": pf16, "preflight_kv4": pf4,
     }

--- a/scripts/h9_e2_kv_workload.py
+++ b/scripts/h9_e2_kv_workload.py
@@ -705,11 +705,15 @@ def _final_verdict(per_length, env):
     pergbs = {L: per_length[L]["per_gb_pass"] for L in lengths}
     all_quality = all(q == "pass" for q in quals.values())
     all_pergb = all(pergbs.values())
+    # For the asterisk path, a None per-GB (both configs skipped at a length) shouldn't drag
+    # an otherwise-clean result down to PARTIAL (code-review R3-low) — judge on the lengths
+    # that actually produced a per-GB number.
+    pergb_where_measured = all(v for v in pergbs.values() if v is not None)
     any_unverified = any(q == "unverified" for q in quals.values())
 
     if all_quality and all_pergb:
         overall = "PASS"
-    elif all_pergb and any_unverified and not any(q == "fail" for q in quals.values()):
+    elif pergb_where_measured and any_unverified and not any(q == "fail" for q in quals.values()):
         overall = "PASS_WITH_ASTERISK"  # e.g. 15K kv16 OOM, quality proven through 12K
     elif quals.get(lengths[0]) == "pass" and quals.get(lengths[1] if len(lengths) > 1 else lengths[0]) == "pass":
         overall = "PARTIAL"


### PR DESCRIPTION
## Summary

Implements **H9-E2 Arm (a)**: validates H7's `kv_bits=4, kv_group_size=64` result on the **real Tier-1 model** (Qwen3-30B-A3B-4bit) at the **real workload context lengths** (10K/12K/15K-token call-transcript summarization), and quantifies effective-context-per-GB of KV cache. Closes the gap between H7 (tiny model, short context) and E3/E5 adopting kv4 as a default.

`scripts/h9_e2_kv_workload.py` (`smoke` + `run`):
- Deterministic synthetic multi-speaker meeting transcripts, tokenizer-trimmed to exact target lengths with the **assistant generation turn preserved** (so the model actually summarizes).
- **Direct KV-cache sizing via `sum(c.nbytes)`** as the per-GB gate metric, cross-checked against an analytic formula (hard 25% validity gate). Analytic ratio = **3.56×**, matching H7's measured compression exactly.
- kv4 routed through `make_prompt_cache` + chunked prefill (512) + `maybe_quantize_kv_cache(quantized_kv_start=0)`, with an `isinstance(c, QuantizedKVCache)` assertion so a silent no-op fails as `infra_fail`, not as a quality result.
- Quality = **teacher-forced summary-only ΔPPL** (same pinned kv16 summary scored under both configs, summary positions only) + ROUGE-L divergence trigger + written summary pairs for spot-check.
- Two-stage memory preflight (pre-load total vs post-load incremental, no weight double-count); kv16-OOM-at-15K → memory PASS-with-asterisk, quality unverified.

**Scope:** 24 GB off-hours MLX engine tier. NOT the 16 GB daily-driver budget; NOT vllm-mlx served (follow-up). Arm (b) (llama.cpp `-ctk q8_0` under ballast) is deferred — blocked on the E1b host-contention baseline.

## Review rounds
- **Plan review: 6 rounds**, 12 findings addressed (converged).
- **Code review: 3 rounds**, 8 findings addressed incl. **one high-severity bug** (prompt builder stripped the chat-template assistant suffix → model wouldn't summarize → whole experiment invalid; fixed and verified). Converged at round 3 (no material findings).
- **Total: 20 findings addressed.**

## ⚠️ Measurement status
Code is complete and verified (ruff clean; prompt-builder + verdict-logic unit-checked), **but the sweep has not run**: the dev machine had **10.9 GB free** at implementation time vs the **~18 GB** the MLX-wired 30B (16.55 GB) needs. This is the documented machine-contention blocker (same as E1 #35 / E1b #41). The sweep is an idle-machine experiment by design — the script's preflight aborts rather than thrash.

**To produce the verdict**, on a quiesced machine (quit Cursor/Chrome/extra Claude procs):
```
uv run python scripts/h9_e2_kv_workload.py smoke   # kv4 compatibility gate
uv run python scripts/h9_e2_kv_workload.py run     # full sweep, logs experiments.jsonl
```
Then fill in findings/verdict in `dev/active/issue-36-h9-e2-kv-quant/context.md`. Leaving #36 open until measured numbers land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)